### PR TITLE
fix(backend): six audit hardening fixes (auth-reset, migrate, invite race, cleanup, rate limits, log forgery)

### DIFF
--- a/cboa-site/lib/clientLogger.ts
+++ b/cboa-site/lib/clientLogger.ts
@@ -50,6 +50,20 @@ let userContext: { id?: string; email?: string } = {}
 let isInitialized = false
 
 /**
+ * Best-effort access-token lookup. Imported lazily to avoid pulling
+ * the Supabase client into modules that only need logging.
+ */
+async function getAuthHeaders(): Promise<Record<string, string>> {
+  try {
+    const { getAuthToken } = await import('./api/client')
+    const token = await getAuthToken()
+    return token ? { Authorization: `Bearer ${token}` } : {}
+  } catch {
+    return {}
+  }
+}
+
+/**
  * Flush logs to the server
  */
 async function flushLogs(): Promise<void> {
@@ -59,9 +73,10 @@ async function flushLogs(): Promise<void> {
   logQueue = []
 
   try {
+    const authHeaders = await getAuthHeaders()
     await fetch('/.netlify/functions/client-logs', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...authHeaders },
       body: JSON.stringify({ logs }),
     })
   } catch (err) {

--- a/cboa-site/netlify/functions/accept-invite.ts
+++ b/cboa-site/netlify/functions/accept-invite.ts
@@ -63,8 +63,19 @@ export const handler: Handler = async (event) => {
       }
     }
 
-    // Check if already used
-    if (inviteToken.used_at) {
+    // Atomically claim the token. If used_at was already set, no row is
+    // returned and a concurrent request has already claimed it. Without
+    // this, two parallel POSTs both passed the JS-side check and both
+    // ran the delete-then-recreate-then-link sequence below.
+    const { data: claimedToken, error: claimError } = await supabaseAdmin
+      .from('invite_tokens')
+      .update({ used_at: new Date().toISOString() })
+      .eq('id', inviteToken.id)
+      .is('used_at', null)
+      .select()
+      .single()
+
+    if (claimError || !claimedToken) {
       logger.info('invite', 'token_already_used', `Token already used for ${inviteToken.email}`)
       return {
         statusCode: 400,
@@ -191,11 +202,7 @@ export const handler: Handler = async (event) => {
         .eq('id', member.id)
     }
 
-    // Mark token as used
-    await supabaseAdmin
-      .from('invite_tokens')
-      .update({ used_at: new Date().toISOString() })
-      .eq('id', inviteToken.id)
+    // Token was already marked used during the atomic claim above.
 
     const redirectUrl = linkData.properties?.action_link || ''
 

--- a/cboa-site/netlify/functions/auth-password-reset.ts
+++ b/cboa-site/netlify/functions/auth-password-reset.ts
@@ -218,10 +218,13 @@ export const handler: Handler = async (event) => {
 
     if (linkError) {
       logger.error('auth', 'password_reset_link_failed', `Failed to generate reset link for ${email}`, new Error(linkError.message))
+      // The user has been confirmed to exist by this point, so the
+      // user-existence enumeration concern is already handled above.
+      // Surface the failure loudly so the UI can show a real error.
       return {
-        statusCode: 200,
+        statusCode: 500,
         headers,
-        body: JSON.stringify({ success: true, message: 'If an account exists, a reset email will be sent.' })
+        body: JSON.stringify({ error: 'Failed to send reset email. Please try again.' })
       }
     }
 

--- a/cboa-site/netlify/functions/client-logs.ts
+++ b/cboa-site/netlify/functions/client-logs.ts
@@ -1,8 +1,11 @@
 import { Handler } from '@netlify/functions'
-import { getCorsHeaders } from './_shared/handler'
+import { getCorsHeaders, supabase } from './_shared/handler'
+import { checkRateLimit, getClientIp } from './_shared/rateLimit'
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+
+const MAX_FIELD_LEN = 4000
 
 interface ClientLogEntry {
   level: 'ERROR' | 'WARN' | 'INFO'
@@ -11,10 +14,13 @@ interface ClientLogEntry {
   message: string
   metadata?: Record<string, unknown>
   errorStack?: string
-  userId?: string
-  userEmail?: string
   url?: string
   timestamp?: string
+}
+
+function clip(s: string | undefined | null, max = MAX_FIELD_LEN): string | null {
+  if (!s) return null
+  return s.length > max ? s.slice(0, max) : s
 }
 
 export const handler: Handler = async (event) => {
@@ -35,6 +41,35 @@ export const handler: Handler = async (event) => {
       statusCode: 405,
       headers,
       body: JSON.stringify({ error: 'Method not allowed' }),
+    }
+  }
+
+  // Rate limit per IP. Without this, the public endpoint can be used to
+  // flood app_logs (cost + storage) and inject fake admin identities.
+  const clientIp = getClientIp(event.headers)
+  if (checkRateLimit(clientIp, { maxRequests: 30, windowMs: 60_000, prefix: 'client-logs' })) {
+    return {
+      statusCode: 429,
+      headers,
+      body: JSON.stringify({ error: 'Too many requests' }),
+    }
+  }
+
+  // Resolve identity from a verified bearer token if present. user_id /
+  // user_email in the request body are ignored — they were attacker-
+  // controlled and could impersonate admins in the triage dashboard.
+  let verifiedUserId: string | null = null
+  let verifiedUserEmail: string | null = null
+  const authHeader = event.headers.authorization || event.headers.Authorization
+  if (authHeader?.startsWith('Bearer ')) {
+    try {
+      const { data: { user } } = await supabase.auth.getUser(authHeader.replace('Bearer ', ''))
+      if (user) {
+        verifiedUserId = user.id
+        verifiedUserEmail = user.email || null
+      }
+    } catch {
+      // Unverified — drop the identity, keep the log.
     }
   }
 
@@ -69,22 +104,22 @@ export const handler: Handler = async (event) => {
     const rows = logs.map((log) => ({
       level: log.level,
       source: 'client',
-      category: log.category,
+      category: clip(log.category, 100),
       function_name: null,
-      action: log.action,
-      message: log.message,
-      user_id: log.userId || null,
-      user_email: log.userEmail || null,
+      action: clip(log.action, 100),
+      message: clip(log.message),
+      user_id: verifiedUserId,
+      user_email: verifiedUserEmail,
       metadata: {
         ...(log.metadata || {}),
-        url: log.url,
+        url: clip(log.url, 500),
         client_timestamp: log.timestamp,
       },
       error_name: log.errorStack ? 'ClientError' : null,
-      error_message: log.level === 'ERROR' ? log.message : null,
-      error_stack: log.errorStack || null,
+      error_message: log.level === 'ERROR' ? clip(log.message) : null,
+      error_stack: clip(log.errorStack),
       ip_address: ipAddress || null,
-      user_agent: userAgent || null,
+      user_agent: clip(userAgent, 500),
     }))
 
     // Insert logs into Supabase

--- a/cboa-site/netlify/functions/migrate-netlify-users.ts
+++ b/cboa-site/netlify/functions/migrate-netlify-users.ts
@@ -1,5 +1,5 @@
 import { Handler } from '@netlify/functions'
-import { supabase as supabaseAdmin, getCorsHeaders } from './_shared/handler'
+import { supabase as supabaseAdmin, getCorsHeaders, listAllAuthUsers } from './_shared/handler'
 import {
   EMAIL_NO_REPLY,
   ORG_NAME,
@@ -171,8 +171,7 @@ export const handler: Handler = async (event) => {
   // Handle backup action - export current Supabase users
   if (action === 'backup') {
     try {
-      const { data: { users }, error } = await supabaseAdmin.auth.admin.listUsers()
-      if (error) throw error
+      const users = await listAllAuthUsers(supabaseAdmin)
 
       return {
         statusCode: 200,
@@ -210,9 +209,8 @@ export const handler: Handler = async (event) => {
   }
 
   try {
-    // Fetch all Supabase users
-    const { data: { users: supabaseUsers }, error: listError } = await supabaseAdmin.auth.admin.listUsers()
-    if (listError) throw listError
+    // Fetch all Supabase users (paginated)
+    const supabaseUsers = await listAllAuthUsers(supabaseAdmin)
 
     const supabaseEmails = new Set(supabaseUsers.map(u => u.email?.toLowerCase()))
 

--- a/cboa-site/netlify/functions/scheduled-log-cleanup.ts
+++ b/cboa-site/netlify/functions/scheduled-log-cleanup.ts
@@ -2,7 +2,7 @@ import { schedule } from '@netlify/functions'
 import { createClient } from '@supabase/supabase-js'
 
 const supabase = createClient(
-  process.env.SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.SUPABASE_SERVICE_ROLE_KEY!
 )
 

--- a/cboa-site/netlify/functions/supabase-auth-admin.ts
+++ b/cboa-site/netlify/functions/supabase-auth-admin.ts
@@ -1,5 +1,6 @@
 import { Handler } from '@netlify/functions'
 import { supabase as supabaseAdmin, getCorsHeaders, listAllAuthUsers, findAuthUserByEmail } from './_shared/handler'
+import { checkRateLimit, getClientIp } from './_shared/rateLimit'
 import { randomBytes } from 'crypto'
 import { Logger } from '../../lib/logger'
 import { recordInviteEmail, recordPasswordResetEmail } from '../../lib/emailHistory'
@@ -290,6 +291,18 @@ export const handler: Handler = async (event) => {
             statusCode: 400,
             headers,
             body: JSON.stringify({ error: 'Email is required' })
+          }
+        }
+
+        // Rate limit: 3 requests per minute per IP. Without this the
+        // endpoint can be used to email-bomb members and burn through
+        // Microsoft Graph quota.
+        const clientIp = getClientIp(event.headers)
+        if (checkRateLimit(clientIp, { maxRequests: 3, windowMs: 60_000, prefix: 'request-invite' })) {
+          return {
+            statusCode: 429,
+            headers,
+            body: JSON.stringify({ error: 'Too many requests. Please try again in a minute.' })
           }
         }
 


### PR DESCRIPTION
## Summary

Six independent backend HIGH-severity fixes from the audit. Each is small and grep-verifiable.

| Audit | GH | Fix |
|---|---|---|
| #9 | #10 | \`auth-password-reset.ts\` — return 500 instead of silent 200 when \`generateLink\` errors |
| #10 | #11 | \`migrate-netlify-users.ts\` — paginate the two \`listUsers()\` calls (sweep follow-up) |
| #11 | #12 | \`accept-invite.ts\` — atomic token claim via \`UPDATE … WHERE used_at IS NULL RETURNING\` |
| #12 | #13 | \`scheduled-log-cleanup.ts\` — fix env var (\`SUPABASE_URL\` → \`NEXT_PUBLIC_SUPABASE_URL\`); cleanup has been a no-op since launch |
| #13 | #14 | \`supabase-auth-admin.ts\` — 3/min/IP rate limit on public \`request_invite\` |
| #14 | #15 | \`client-logs.ts\` — 30/min/IP rate limit, ignore body-supplied user_id/user_email (forgeable), resolve identity from a verified bearer token, clip oversized fields. \`clientLogger\` now forwards the access token so authenticated logs keep their attribution. |

## Test plan

- [ ] Forgot Password with a valid email but a Supabase config that triggers \`generateLink\` failure → UI now shows an error toast (was: silent success)
- [ ] migrate-netlify-users \`backup\` action with > 50 users → JSON \`count\` matches actual user count (was: capped at 50)
- [ ] Two parallel POSTs to \`/.netlify/functions/accept-invite\` with the same token → first returns 200, second returns "Invite already used" (was: both ran)
- [ ] Verify Netlify scheduled function logs after next Sunday 03:00 UTC — no \`TypeError: Invalid URL\`
- [ ] Loop \`curl -X POST -d '{"action":"request_invite","email":"x"}'\` 5x rapidly → 4th hits 429
- [ ] Loop POST to \`/.netlify/functions/client-logs\` 35x in a minute from one IP → request 31+ hits 429
- [ ] Submit a client log with \`userEmail: "admin@cboa.ca"\` from an anonymous browser → row in \`app_logs\` has \`user_email = NULL\` (was: stored as admin)
- [ ] Submit from a logged-in session → row has the real verified email (regression check)

Closes #10
Closes #11
Closes #12
Closes #13
Closes #14
Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)
