### PR TITLE
fix(frontend): admin role gates, broken /portal/login links, deep-link preservation

### DIFF
--- a/cboa-site/app/accept-invite/page.tsx
+++ b/cboa-site/app/accept-invite/page.tsx
@@ -117,7 +117,7 @@ function AcceptInviteContent() {
                 <div className="space-y-3">
                   {errorType === 'active' || errorType === 'used' ? (
                     <Link
-                      href="/portal/login"
+                      href="/login"
                       className="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium transition-colors"
                     >
                       Go to Login

--- a/cboa-site/app/get-invite/page.tsx
+++ b/cboa-site/app/get-invite/page.tsx
@@ -116,7 +116,7 @@ export default function GetInvitePage() {
                       {result.message}
                     </p>
                     <Link
-                      href="/portal/login"
+                      href="/login"
                       className="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium transition-colors"
                     >
                       Go to Login
@@ -165,7 +165,7 @@ export default function GetInvitePage() {
           <div className="px-6 py-4 bg-gray-50 dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 text-center">
             <p className="text-sm text-gray-500 dark:text-gray-400">
               Already have an account?{' '}
-              <Link href="/portal/login" className="text-orange-500 hover:text-orange-600 font-medium">
+              <Link href="/login" className="text-orange-500 hover:text-orange-600 font-medium">
                 Sign in here
               </Link>
             </p>

--- a/cboa-site/app/portal/admin/contact-submissions/page.tsx
+++ b/cboa-site/app/portal/admin/contact-submissions/page.tsx
@@ -10,6 +10,7 @@ import {
   SortingState,
 } from '@tanstack/react-table'
 import { createBrowserClient } from '@supabase/ssr'
+import { useAdminGuard } from '@/hooks/useAdminGuard'
 import {
   IconArrowUp,
   IconArrowDown,
@@ -242,6 +243,7 @@ function ContactDetailModal({
 }
 
 export default function ContactSubmissionsPage() {
+  useAdminGuard()
   const [submissions, setSubmissions] = useState<ContactSubmission[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)

--- a/cboa-site/app/portal/admin/email-history/page.tsx
+++ b/cboa-site/app/portal/admin/email-history/page.tsx
@@ -10,6 +10,7 @@ import {
   SortingState,
 } from '@tanstack/react-table'
 import { createBrowserClient } from '@supabase/ssr'
+import { useAdminGuard } from '@/hooks/useAdminGuard'
 import {
   IconArrowUp,
   IconArrowDown,
@@ -293,6 +294,7 @@ function EmailDetailModal({
 }
 
 export default function EmailHistoryPage() {
+  useAdminGuard()
   const [emails, setEmails] = useState<EmailHistoryRecord[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)

--- a/cboa-site/app/portal/admin/logs/page.tsx
+++ b/cboa-site/app/portal/admin/logs/page.tsx
@@ -12,6 +12,7 @@ import {
   SortingState,
 } from '@tanstack/react-table'
 import { createBrowserClient } from '@supabase/ssr'
+import { useAdminGuard } from '@/hooks/useAdminGuard'
 import {
   IconArrowUp,
   IconArrowDown,
@@ -75,6 +76,7 @@ const supabase = createBrowserClient(
 )
 
 export default function AdminLogsPage() {
+  useAdminGuard()
   const [activeTab, setActiveTab] = useState<'app' | 'audit'>('app')
   const [appLogs, setAppLogs] = useState<AppLog[]>([])
   const [auditLogs, setAuditLogs] = useState<AuditLog[]>([])

--- a/cboa-site/app/portal/admin/osa-submissions/page.tsx
+++ b/cboa-site/app/portal/admin/osa-submissions/page.tsx
@@ -10,6 +10,7 @@ import {
   SortingState,
 } from '@tanstack/react-table'
 import { createBrowserClient } from '@supabase/ssr'
+import { useAdminGuard } from '@/hooks/useAdminGuard'
 import {
   IconArrowUp,
   IconArrowDown,
@@ -410,6 +411,7 @@ function OSADetailModal({
 }
 
 export default function OSASubmissionsPage() {
+  useAdminGuard()
   const [submissions, setSubmissions] = useState<OSASubmission[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)

--- a/cboa-site/app/portal/admin/page.tsx
+++ b/cboa-site/app/portal/admin/page.tsx
@@ -2,6 +2,8 @@
 
 import React, { useEffect } from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useRole } from '@/contexts/RoleContext'
 import {
   IconWorld,
   IconArticle,
@@ -17,15 +19,14 @@ import {
 } from '@tabler/icons-react'
 
 export default function PortalAdmin() {
-  useEffect(() => {
-    // Check if user has admin/executive role
-    // In production, this would be a proper auth check
-    const userRole: string = 'executive' // Mock role
+  const router = useRouter()
+  const { user } = useRole()
 
-    if (userRole !== 'admin' && userRole !== 'executive') {
-      window.location.href = '/portal'
+  useEffect(() => {
+    if (user.role !== 'admin' && user.role !== 'executive') {
+      router.push('/portal')
     }
-  }, [])
+  }, [user.role, router])
 
   const adminSections: {
     title: string

--- a/cboa-site/components/AuthGuard.tsx
+++ b/cboa-site/components/AuthGuard.tsx
@@ -66,10 +66,13 @@ export default function AuthGuard({
         return
       }
 
-      // Store intended destination for after login
-      sessionStorage.setItem('redirectAfterLogin', pathname)
-      // Redirect to login page
-      router.push(`/login?redirect=${encodeURIComponent(pathname)}`)
+      // Store intended destination for after login. Preserve the
+      // query string so deep-linked content (news?id=…, calendar?evt=…
+      // etc.) doesn't drop back to the index page after login.
+      const search = typeof window !== 'undefined' ? window.location.search : ''
+      const target = pathname + search
+      sessionStorage.setItem('redirectAfterLogin', target)
+      router.push(`/login?redirect=${encodeURIComponent(target)}`)
     }
   }, [isAuthenticated, isLoading, requireAuth, pathname, shouldBypassAuth, hasRedirected, router, hasToken])
 

--- a/cboa-site/contexts/AuthContext.tsx
+++ b/cboa-site/contexts/AuthContext.tsx
@@ -312,6 +312,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         return { error: data.error || 'Failed to send reset email' }
       }
 
+      // Belt-and-suspenders: even if the server returned 2xx, treat
+      // an explicit `success: false` as an error so we don't show the
+      // "check your email" UI when nothing was sent.
+      if (data && data.success === false) {
+        clientLogger.warn('auth', 'reset_password_failed', `Password reset reported failure: ${data.error}`, { email })
+        return { error: data.error || 'Failed to send reset email' }
+      }
+
       clientLogger.info('auth', 'reset_password_requested', `Password reset requested for: ${email}`)
       return {}
     } catch (error: any) {

--- a/cboa-site/hooks/useAdminGuard.ts
+++ b/cboa-site/hooks/useAdminGuard.ts
@@ -1,0 +1,22 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useRole } from '@/contexts/RoleContext'
+
+/**
+ * Redirect non-admin users away from admin-only pages. Server-side
+ * gates remain authoritative — this keeps non-admins from seeing the
+ * page chrome and "Failed to fetch" toasts when they shouldn't be
+ * here at all.
+ */
+export function useAdminGuard(redirectTo = '/portal') {
+  const router = useRouter()
+  const { user } = useRole()
+
+  useEffect(() => {
+    if (user.role !== 'admin') {
+      router.push(redirectTo)
+    }
+  }, [user.role, router, redirectTo])
+}


### PR DESCRIPTION
## Summary

Five frontend audit fixes — small, mostly mechanical.

| Audit | GH | Fix |
|---|---|---|
| #5  | #6  | \`/portal/admin\` role check was hardcoded \`userRole = 'executive'\`. Now uses \`useRole()\`. |
| #20 | #21 | \`accept-invite\` and \`get-invite\` linked to \`/portal/login\` (404). Real route is \`/login\` — three hrefs corrected. |
| #22 | #23 | Admin sub-pages (logs, email-history, contact-submissions, osa-submissions) had no client-side role guard. Added \`useAdminGuard()\` hook. |
| #24 | #25 | \`forgot-password\` client only checked \`response.ok\`; now also rejects 2xx with \`success: false\` so the silent-success pattern doesn't show "check your email" when nothing was sent. |
| #35 | #36 | \`AuthGuard\` stored \`pathname\` only when redirecting; deep-links like \`/portal/news?id=abc\` lost the query string after login. Now preserves \`pathname + search\`. |

\`#21\` (login redirect race) is deferred to its own PR after #40 lands, to avoid a merge conflict on the same useEffect block.

## Test plan

- [ ] \`/portal/admin\` as a basic 'official' → redirects to \`/portal\` (was: showed admin link grid)
- [ ] \`/portal/admin/logs\` (and the other 3 sub-pages) as basic 'official' → redirects to \`/portal\` (was: page chrome + error toast)
- [ ] Click "Go to Login" on \`/accept-invite?token=already-used\` → lands on \`/login\` (was: 404 at \`/portal/login\`)
- [ ] Forgot Password with a valid email → "Check your email" still shown on success
- [ ] Mock the server to return \`200 { success: false, error: 'X' }\` → form shows error X (was: showed "Check your email")
- [ ] Visit \`/portal/news?id=abc\` while logged out → after login, lands on \`/portal/news?id=abc\` (was: \`/portal/news\`)

Closes #6
Closes #21
Closes #23
Closes #25
Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)