### PR TITLE
fix: six small audit fixes — pagination, env docs, deps, secrets, UX

### DIFF
--- a/cboa-site/.env.example
+++ b/cboa-site/.env.example
@@ -35,3 +35,26 @@ SHAREPOINT_CLIENT_SECRET=your-client-secret-from-azure
 SHAREPOINT_SITE_ID=get-from-graph-explorer
 SHAREPOINT_DRIVE_ID=get-from-graph-explorer
 SHAREPOINT_WORKBOOK_ID=get-from-excel-url
+
+# Microsoft Graph API (for sending emails — invites, password resets,
+# contact form, OSA webhook, member sync). Required by every
+# email-sending function. Without these, password reset and other
+# email flows will return 500 "Email service not configured".
+MICROSOFT_TENANT_ID=your-azure-tenant-id
+MICROSOFT_CLIENT_ID=your-graph-app-client-id
+MICROSOFT_CLIENT_SECRET=your-graph-app-client-secret
+
+# OSA Webhook (Officiating Services Agreement form submission auth)
+# Required — without this the webhook accepts unauthenticated POSTs.
+OSA_WEBHOOK_SECRET=generate-a-random-secret
+
+# Email verification HMAC (contact form code verification)
+# Required — the function falls back to MICROSOFT_CLIENT_SECRET then
+# to empty string, which would let any attacker forge a verification.
+EMAIL_VERIFY_SECRET=generate-a-random-secret
+
+# Migration secret (used by migrate-netlify-users.ts admin tooling)
+MIGRATION_SECRET=generate-a-random-secret
+
+# Google Safe Browsing (URL safety checks for contact-form attachments)
+GOOGLE_SAFE_BROWSING_API_KEY=your-google-safe-browsing-key

--- a/cboa-site/app/accept-invite/page.tsx
+++ b/cboa-site/app/accept-invite/page.tsx
@@ -38,7 +38,15 @@ function AcceptInviteContent() {
         if (data.success && data.redirectUrl) {
           setStatus('redirecting')
           setMessage('Redirecting to complete your account setup...')
-          // Redirect to Supabase magic link
+          // Recover from a stuck redirect — if the navigation hasn't
+          // moved the page in 10 seconds (Supabase magic-link slow or
+          // unreachable), surface an error instead of an indefinite
+          // spinner.
+          setTimeout(() => {
+            setStatus('error')
+            setErrorType('general')
+            setMessage('The invite redirect is taking too long. Please try again or request a new invite.')
+          }, 10_000)
           window.location.href = data.redirectUrl
         } else if (data.alreadyUsed) {
           setStatus('error')

--- a/cboa-site/lib/siteConfig.ts
+++ b/cboa-site/lib/siteConfig.ts
@@ -87,6 +87,13 @@ export const EMAIL_SUBJECTS = {
 export const getPortalUrl = (): string => `${SITE_URL}${PORTAL_PATH}`
 export const getContactUrl = (category?: string): string =>
   category ? `${SITE_URL}${CONTACT_PATH}?category=${category}` : `${SITE_URL}${CONTACT_PATH}`
+/**
+ * SECURITY: never thread user-supplied input (e.g. ?redirect= query
+ * params) into this URL or into Supabase generateLink({ redirectTo }).
+ * Doing so turns the auth flow into an open redirect through Supabase's
+ * allow-listed domain. Keep the callback URL hardcoded here; deep-link
+ * targets should be carried in app-level state, not in redirectTo.
+ */
 export const getAuthCallbackUrl = (): string => `${SITE_URL}/auth/callback`
 
 // Configuration object for easy import

--- a/cboa-site/netlify/functions/accept-invite.ts
+++ b/cboa-site/netlify/functions/accept-invite.ts
@@ -1,9 +1,7 @@
 import { Handler } from '@netlify/functions'
 import { supabase as supabaseAdmin, getCorsHeaders } from './_shared/handler'
 import { Logger } from '../../lib/logger'
-import { SITE_URL, ORG_SHORT_NAME } from '../../lib/siteConfig'
-
-const siteUrl = SITE_URL
+import { ORG_SHORT_NAME, getAuthCallbackUrl } from '../../lib/siteConfig'
 
 /**
  * Accept Invite - Proxy for Supabase magic links
@@ -178,7 +176,7 @@ export const handler: Handler = async (event) => {
           name: member.name || inviteToken.name,
           role: member.role || inviteToken.role || 'official'
         },
-        redirectTo: `${siteUrl}/auth/callback`
+        redirectTo: getAuthCallbackUrl()
       }
     })
 

--- a/cboa-site/netlify/functions/auth-password-reset.ts
+++ b/cboa-site/netlify/functions/auth-password-reset.ts
@@ -14,6 +14,7 @@ import {
   getContactUrl,
   getPortalUrl,
   getCopyrightYear,
+  getAuthCallbackUrl,
   EMAIL_SUBJECTS,
 } from '../../lib/siteConfig'
 
@@ -212,7 +213,7 @@ export const handler: Handler = async (event) => {
       type: 'recovery',
       email,
       options: {
-        redirectTo: `${siteUrl}/auth/callback`
+        redirectTo: getAuthCallbackUrl()
       }
     })
 

--- a/cboa-site/netlify/functions/send-email.ts
+++ b/cboa-site/netlify/functions/send-email.ts
@@ -114,14 +114,23 @@ async function getRecipientEmails(
     return Array.from(emails)
   }
 
-  // Use the shared Supabase client instead of raw REST
-  const { data: members, error } = await supabase
-    .from('members')
-    .select('email, role, certification_level, rank')
-
-  if (error || !members) {
-    console.error('Failed to fetch members:', error?.message)
-    return Array.from(emails)
+  // Paginate — PostgREST defaults to 1000 rows. Once the membership
+  // grows past 1000, an unpaginated fetch would silently miss everyone
+  // beyond row 1000 and the bulk send would stop including them.
+  const PAGE = 1000
+  const members: Array<{ email: string | null, role: string | null, certification_level: string | null, rank: string | null }> = []
+  for (let start = 0; ; start += PAGE) {
+    const { data, error } = await supabase
+      .from('members')
+      .select('email, role, certification_level, rank')
+      .range(start, start + PAGE - 1)
+    if (error) {
+      console.error('Failed to fetch members:', error.message)
+      return Array.from(emails)
+    }
+    if (!data || data.length === 0) break
+    members.push(...data)
+    if (data.length < PAGE) break
   }
 
   for (const member of members) {

--- a/cboa-site/netlify/functions/send-email.ts
+++ b/cboa-site/netlify/functions/send-email.ts
@@ -118,7 +118,7 @@ async function getRecipientEmails(
   // grows past 1000, an unpaginated fetch would silently miss everyone
   // beyond row 1000 and the bulk send would stop including them.
   const PAGE = 1000
-  const members: Array<{ email: string | null, role: string | null, certification_level: string | null, rank: string | null }> = []
+  const members: Array<{ email: string | null, role: string | null, certification_level: string | null, rank: number | null }> = []
   for (let start = 0; ; start += PAGE) {
     const { data, error } = await supabase
       .from('members')

--- a/cboa-site/netlify/functions/supabase-auth-admin.ts
+++ b/cboa-site/netlify/functions/supabase-auth-admin.ts
@@ -15,6 +15,7 @@ import {
   getContactUrl,
   getPortalUrl,
   getCopyrightYear,
+  getAuthCallbackUrl,
   EMAIL_SUBJECTS,
   PORTAL_FEATURES,
 } from '../../lib/siteConfig'
@@ -851,7 +852,7 @@ export const handler: Handler = async (event) => {
             type: 'recovery',
             email,
             options: {
-              redirectTo: `${siteUrl}/auth/callback`
+              redirectTo: getAuthCallbackUrl()
             }
           })
 

--- a/cboa-site/netlify/functions/verify-email.ts
+++ b/cboa-site/netlify/functions/verify-email.ts
@@ -9,8 +9,14 @@ import { EMAIL_NO_REPLY, EMAIL_ANNOUNCEMENTS, ORG_NAME } from '../../lib/siteCon
 const VERIFICATION_TTL_MS = 10 * 60 * 1000 // 10 minutes
 
 function getHmacSecret(): string {
-  // Use a dedicated secret or fall back to the MS client secret
-  return process.env.EMAIL_VERIFY_SECRET || process.env.MICROSOFT_CLIENT_SECRET || ''
+  // Prefer the dedicated secret; fall back to the MS client secret.
+  // Refuse to run with an empty key — otherwise any attacker can
+  // mint a valid token by computing hmac('', payload).
+  const secret = process.env.EMAIL_VERIFY_SECRET || process.env.MICROSOFT_CLIENT_SECRET
+  if (!secret) {
+    throw new Error('EMAIL_VERIFY_SECRET (or MICROSOFT_CLIENT_SECRET fallback) must be set')
+  }
+  return secret
 }
 
 /**


### PR DESCRIPTION
## Summary

Six small audit fixes bundled — each touches one concern.

| Audit | GH | Fix |
|---|---|---|
| #29 | #30 | \`send-email.ts\` paginate \`members\` fetch (1000 row default cap was about to bite once membership grew) |
| #31 | #32 | \`.env.example\` add \`MICROSOFT_*\`, \`OSA_WEBHOOK_SECRET\`, \`EMAIL_VERIFY_SECRET\`, \`MIGRATION_SECRET\`, \`GOOGLE_SAFE_BROWSING_API_KEY\` |
| #33 | #34 | \`osa-webhook.ts\` swap transitive \`uuid\` for Node's \`crypto.randomUUID()\` |
| #34 | #35 | \`verify-email.ts\` throw if HMAC secret falls back to '' (would let any attacker mint a valid token) |
| #36 | #37 | \`accept-invite/page.tsx\` add 10s timeout on the redirect spinner |
| #37 | #38 | \`getAuthCallbackUrl()\` helper with SECURITY comment forbidding user-input wiring; three callers switched to use it |

\`members.ts\` also has a \`redirectTo\` but is intentionally skipped here — PR #41 rewrites that file, so catching it in a follow-up after #41 lands.

## Test plan

- [ ] Bulk-send to "all members" with > 1000 members → all get the email (was: capped at 1000)
- [ ] Spin up a fresh deploy with only the documented env vars from \`.env.example\` → all email features at least *try* to work (no silent "service not configured" gaps for vars that weren't documented)
- [ ] OSA webhook submission still produces a unique \`submission_group_id\` per submission
- [ ] Set both \`EMAIL_VERIFY_SECRET\` and \`MICROSOFT_CLIENT_SECRET\` to empty → contact-form verification function refuses to start (was: silently used \`''\` as the HMAC key)
- [ ] Trigger an invite where the magic-link redirect is slow → after 10s, page shows "taking too long" with a retry CTA (was: indefinite spinner)
- [ ] Existing password reset / invite / accept-invite flows continue to work end-to-end (regression check on the \`redirectTo\` refactor)

Closes #30
Closes #32
Closes #34
Closes #35
Closes #37
Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)