### PR TITLE
fix(contact): verify code server-side before flipping UI to verified

### DIFF
--- a/cboa-site/components/forms/ContactForm.tsx
+++ b/cboa-site/components/forms/ContactForm.tsx
@@ -697,11 +697,34 @@ export default function ContactForm() {
                     <input
                       type="text"
                       value={verificationCode}
-                      onChange={(e) => {
+                      onChange={async (e) => {
                         const val = e.target.value.replace(/\D/g, '').slice(0, 6)
                         setVerificationCode(val)
                         if (val.length === 6) {
-                          setVerificationStatus('verified')
+                          // Verify with the server before flipping to
+                          // 'verified'. Without this, the UI happily
+                          // claims any six digits are valid even though
+                          // the backend would later reject the submit.
+                          try {
+                            const res = await fetch('/.netlify/functions/verify-email', {
+                              method: 'POST',
+                              headers: { 'Content-Type': 'application/json' },
+                              body: JSON.stringify({
+                                email: watchedEmail,
+                                token: verificationToken,
+                                code: val,
+                              }),
+                            })
+                            const result = await res.json()
+                            if (res.ok && result.valid) {
+                              setVerificationError('')
+                              setVerificationStatus('verified')
+                            } else {
+                              setVerificationError(result.error || 'Incorrect code. Please check the email and try again.')
+                            }
+                          } catch {
+                            setVerificationError('Could not verify the code. Please try again.')
+                          }
                         }
                       }}
                       maxLength={6}

--- a/cboa-site/netlify/functions/verify-email.ts
+++ b/cboa-site/netlify/functions/verify-email.ts
@@ -112,10 +112,21 @@ export const handler: Handler = async (event) => {
   }
 
   try {
-    const { email } = JSON.parse(event.body || '{}')
+    const { email, code, token } = JSON.parse(event.body || '{}')
 
     if (!email) {
       return { statusCode: 400, headers, body: JSON.stringify({ error: 'Email is required' }) }
+    }
+
+    // Verification mode: caller has a token and a 6-digit code, wants
+    // to know if they match. Used by the ContactForm to confirm the
+    // code server-side before showing a "verified" UI state.
+    if (code && token) {
+      const result = verifyEmailToken(token, email, code)
+      if (result.valid) {
+        return { statusCode: 200, headers, body: JSON.stringify({ success: true, valid: true }) }
+      }
+      return { statusCode: 400, headers, body: JSON.stringify({ success: false, valid: false, error: result.reason || 'Invalid code' }) }
     }
 
     // Validate the email first (MX check, disposable blocking)

--- a/cboa-site/netlify/functions/verify-email.ts
+++ b/cboa-site/netlify/functions/verify-email.ts
@@ -112,7 +112,7 @@ export const handler: Handler = async (event) => {
   }
 
   try {
-    const { email, code, token } = JSON.parse(event.body || '{}')
+    const { email, code: providedCode, token: providedToken } = JSON.parse(event.body || '{}')
 
     if (!email) {
       return { statusCode: 400, headers, body: JSON.stringify({ error: 'Email is required' }) }
@@ -121,8 +121,8 @@ export const handler: Handler = async (event) => {
     // Verification mode: caller has a token and a 6-digit code, wants
     // to know if they match. Used by the ContactForm to confirm the
     // code server-side before showing a "verified" UI state.
-    if (code && token) {
-      const result = verifyEmailToken(token, email, code)
+    if (providedCode && providedToken) {
+      const result = verifyEmailToken(providedToken, email, providedCode)
       if (result.valid) {
         return { statusCode: 200, headers, body: JSON.stringify({ success: true, valid: true }) }
       }


### PR DESCRIPTION
## Summary

Closes audit #25.

The ContactForm previously flipped \`verificationStatus = 'verified'\` purely on local 6-character input length, so any six random digits unlocked the submit button. The backend would still reject a wrong code at final submit, but the UI lied to the user.

- \`verify-email.ts\` now supports a verification mode: \`{ email, code, token }\` → returns \`{ valid: boolean }\` via the existing \`verifyEmailToken()\` helper. The original \`{ email }\` shape (request a code) is preserved.
- \`ContactForm\` calls that endpoint when six digits are entered. Only flips to \`verified\` on success.

## Test plan

- [ ] Enter the correct 6-digit code → status flips to verified
- [ ] Enter six wrong digits → status stays at "sent", error message shown, submit button stays disabled
- [ ] Resend code, enter the new code → verifies correctly
- [ ] Network failure during verify → shows generic "could not verify" error

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)