### PR TITLE
fix(supabase): consolidate createBrowserClient call sites to one singleton

### DIFF
--- a/cboa-site/app/auth/callback/page.tsx
+++ b/cboa-site/app/auth/callback/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { createBrowserClient } from '@supabase/ssr'
+import { getSupabaseBrowserClient } from '@/lib/api/client'
 import { IconLoader2, IconAlertCircle } from '@tabler/icons-react'
 
 export default function AuthCallbackPage() {
@@ -12,10 +12,7 @@ export default function AuthCallbackPage() {
   useEffect(() => {
     const handleAuthCallback = async () => {
       try {
-        const supabase = createBrowserClient(
-          process.env.NEXT_PUBLIC_SUPABASE_URL!,
-          process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-        )
+        const supabase = getSupabaseBrowserClient()
 
         // Get the hash fragment from the URL
         const hashParams = new URLSearchParams(window.location.hash.substring(1))

--- a/cboa-site/app/auth/complete-profile/page.tsx
+++ b/cboa-site/app/auth/complete-profile/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, Suspense } from 'react'
 import { useRouter } from 'next/navigation'
-import { createBrowserClient } from '@supabase/ssr'
+import { getSupabaseBrowserClient } from '@/lib/api/client'
 import { IconUser, IconLoader2, IconAlertCircle, IconCheck, IconPhone, IconHome, IconUserHeart } from '@tabler/icons-react'
 
 const PHONE_REGEX = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/
@@ -75,10 +75,7 @@ function CompleteProfileForm() {
     emergency_contact_phone: ''
   })
 
-  const supabase = createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  )
+  const supabase = getSupabaseBrowserClient()
 
   // Check auth and load existing member data
   useEffect(() => {

--- a/cboa-site/app/auth/set-password/page.tsx
+++ b/cboa-site/app/auth/set-password/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { createBrowserClient } from '@supabase/ssr'
+import { getSupabaseBrowserClient } from '@/lib/api/client'
 import { IconLock, IconLoader2, IconAlertCircle, IconCheck } from '@tabler/icons-react'
 
 function SetPasswordForm() {
@@ -17,10 +17,7 @@ function SetPasswordForm() {
   const [isAuthenticated, setIsAuthenticated] = useState(false)
   const [checkingAuth, setCheckingAuth] = useState(true)
 
-  const supabase = createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  )
+  const supabase = getSupabaseBrowserClient()
 
   // Check if user is authenticated
   useEffect(() => {

--- a/cboa-site/app/home-content.tsx
+++ b/cboa-site/app/home-content.tsx
@@ -26,12 +26,12 @@ export default function HomeContent() {
         if (newsError) throw newsError
 
         const news = (allNews || [])
-          .sort((a, b) => {
+          .sort((a: any, b: any) => {
             if (a.priority !== b.priority) return b.priority - a.priority
             return new Date(b.published_date).getTime() - new Date(a.published_date).getTime()
           })
           .slice(0, 3)
-          .map(news => ({
+          .map((news: any) => ({
             title: news.title,
             date: news.published_date,
             excerpt: news.excerpt,
@@ -52,7 +52,7 @@ export default function HomeContent() {
         if (trainingError) throw trainingError
 
         const training = (events || [])
-          .map(training => ({
+          .map((training: any) => ({
             title: training.title,
             date: training.event_date,
             time: training.event_time ? `${training.event_time} - ${

--- a/cboa-site/app/portal/admin/contact-submissions/page.tsx
+++ b/cboa-site/app/portal/admin/contact-submissions/page.tsx
@@ -9,7 +9,7 @@ import {
   ColumnDef,
   SortingState,
 } from '@tanstack/react-table'
-import { createBrowserClient } from '@supabase/ssr'
+import { getSupabaseBrowserClient } from '@/lib/api/client'
 import { useAdminGuard } from '@/hooks/useAdminGuard'
 import {
   IconArrowUp,
@@ -56,10 +56,7 @@ interface PaginationInfo {
   totalPages: number
 }
 
-const supabase = createBrowserClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-)
+const supabase = getSupabaseBrowserClient()
 
 const statusConfig: Record<string, { label: string; icon: React.ElementType; color: string }> = {
   new: { label: 'New', icon: IconClock, color: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-400' },

--- a/cboa-site/app/portal/admin/email-history/page.tsx
+++ b/cboa-site/app/portal/admin/email-history/page.tsx
@@ -9,7 +9,7 @@ import {
   ColumnDef,
   SortingState,
 } from '@tanstack/react-table'
-import { createBrowserClient } from '@supabase/ssr'
+import { getSupabaseBrowserClient } from '@/lib/api/client'
 import { useAdminGuard } from '@/hooks/useAdminGuard'
 import {
   IconArrowUp,
@@ -57,10 +57,7 @@ interface PaginationInfo {
   totalPages: number
 }
 
-const supabase = createBrowserClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-)
+const supabase = getSupabaseBrowserClient()
 
 const emailTypeConfig: Record<string, { label: string; icon: React.ElementType; color: string }> = {
   bulk: { label: 'Bulk', icon: IconUsers, color: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-400' },

--- a/cboa-site/app/portal/admin/logs/page.tsx
+++ b/cboa-site/app/portal/admin/logs/page.tsx
@@ -11,7 +11,7 @@ import {
   ColumnDef,
   SortingState,
 } from '@tanstack/react-table'
-import { createBrowserClient } from '@supabase/ssr'
+import { getSupabaseBrowserClient } from '@/lib/api/client'
 import { useAdminGuard } from '@/hooks/useAdminGuard'
 import {
   IconArrowUp,
@@ -70,10 +70,7 @@ interface PaginationInfo {
   totalPages: number
 }
 
-const supabase = createBrowserClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-)
+const supabase = getSupabaseBrowserClient()
 
 export default function AdminLogsPage() {
   useAdminGuard()

--- a/cboa-site/app/portal/admin/osa-submissions/page.tsx
+++ b/cboa-site/app/portal/admin/osa-submissions/page.tsx
@@ -9,7 +9,7 @@ import {
   ColumnDef,
   SortingState,
 } from '@tanstack/react-table'
-import { createBrowserClient } from '@supabase/ssr'
+import { getSupabaseBrowserClient } from '@/lib/api/client'
 import { useAdminGuard } from '@/hooks/useAdminGuard'
 import {
   IconArrowUp,
@@ -81,10 +81,7 @@ interface PaginationInfo {
   totalPages: number
 }
 
-const supabase = createBrowserClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-)
+const supabase = getSupabaseBrowserClient()
 
 const eventTypeConfig: Record<string, { label: string; icon: React.ElementType; color: string }> = {
   'Exhibition Game(s)': { label: 'Exhibition', icon: IconBallBasketball, color: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-400' },

--- a/cboa-site/components/AuthErrorHandler.tsx
+++ b/cboa-site/components/AuthErrorHandler.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { createBrowserClient } from '@supabase/ssr'
+import { getSupabaseBrowserClient } from '@/lib/api/client'
 import { IconAlertCircle, IconX, IconLoader2 } from '@tabler/icons-react'
 
 export default function AuthErrorHandler() {
@@ -44,10 +44,7 @@ export default function AuthErrorHandler() {
         setIsProcessing(true)
 
         try {
-          const supabase = createBrowserClient(
-            process.env.NEXT_PUBLIC_SUPABASE_URL!,
-            process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-          )
+          const supabase = getSupabaseBrowserClient()
 
           const { error: sessionError } = await supabase.auth.setSession({
             access_token: accessToken,

--- a/cboa-site/components/PasswordChangeModal.tsx
+++ b/cboa-site/components/PasswordChangeModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { createBrowserClient } from '@supabase/ssr'
+import { getSupabaseBrowserClient } from '@/lib/api/client'
 import { IconLock, IconLoader2, IconAlertCircle, IconCheck, IconX } from '@tabler/icons-react'
 
 interface PasswordChangeModalProps {
@@ -17,10 +17,7 @@ export default function PasswordChangeModal({ isOpen, onClose, onSuccess, userEm
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const supabase = createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  )
+  const supabase = getSupabaseBrowserClient()
 
   if (!isOpen) return null
 

--- a/cboa-site/contexts/AuthContext.tsx
+++ b/cboa-site/contexts/AuthContext.tsx
@@ -187,7 +187,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     // Set up auth state change listener
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
-      async (event, session) => {
+      async (event: string, session: any) => {
         console.log('Auth state changed:', event)
 
         if (event === 'SIGNED_IN' && session?.user) {

--- a/cboa-site/contexts/AuthContext.tsx
+++ b/cboa-site/contexts/AuthContext.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
-import { createBrowserClient } from '@supabase/ssr'
+import { getSupabaseBrowserClient } from '@/lib/api/client'
 import { membersAPI } from '@/lib/api'
 import { clientLogger } from '@/lib/clientLogger'
 import type { User as SupabaseUser, Session } from '@supabase/supabase-js'
@@ -32,10 +32,7 @@ interface AuthContextType {
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
 // Create Supabase browser client
-const supabase = createBrowserClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-)
+const supabase = getSupabaseBrowserClient()
 
 // Map Supabase user metadata to our app roles
 function getUserRole(supabaseUser: SupabaseUser | null): UserRole {

--- a/cboa-site/lib/api/client.ts
+++ b/cboa-site/lib/api/client.ts
@@ -14,10 +14,16 @@ export const USE_MOCK_DATA = process.env.NEXT_PUBLIC_USE_MOCK_DATA === 'true' ||
 
 export const isBrowser = () => typeof window !== 'undefined'
 
-// Lazily-created browser client that shares session with AuthContext
+/**
+ * Singleton browser-side Supabase client. Every client component
+ * that needs Supabase should import this — instantiating multiple
+ * createBrowserClient() calls causes "Multiple GoTrueClient
+ * instances detected" warnings and real auth-state desync (one
+ * client updates a password while a second client's listener never
+ * fires because it owns a different in-memory session).
+ */
 let _browserClient: ReturnType<typeof createBrowserClient> | null = null
-function getBrowserClient() {
-  if (!isBrowser()) return null
+export function getSupabaseBrowserClient(): ReturnType<typeof createBrowserClient> {
   if (!_browserClient) {
     _browserClient = createBrowserClient(
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -29,8 +35,8 @@ function getBrowserClient() {
 
 // Get Supabase auth token for authenticated API calls
 async function getAuthHeaders(): Promise<Record<string, string>> {
-  const client = getBrowserClient()
-  if (!client) return {}
+  if (!isBrowser()) return {}
+  const client = getSupabaseBrowserClient()
   try {
     const { data: { session } } = await client.auth.getSession()
     if (session?.access_token) {
@@ -82,8 +88,8 @@ export { retryAsync }
 
 /** Get the current user's JWT token from Supabase session */
 export async function getAuthToken(): Promise<string | null> {
-  const client = getBrowserClient()
-  if (!client) return null
+  if (!isBrowser()) return null
+  const client = getSupabaseBrowserClient()
   try {
     const { data: { session } } = await client.auth.getSession()
     return session?.access_token || null

--- a/cboa-site/lib/fileUpload.ts
+++ b/cboa-site/lib/fileUpload.ts
@@ -1,12 +1,8 @@
 import { validators, AppError } from './errorHandling'
-import { createClient } from '@supabase/supabase-js'
+import { getSupabaseBrowserClient } from './api/client'
 
 const MAX_FILE_SIZE_MB = 25
 const ALLOWED_FILE_TYPES = ['pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'mp4', 'avi', 'mov', 'jpg', 'jpeg', 'png']
-
-// Initialize Supabase client for direct uploads
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
 
 function getContentType(filename: string): string {
   const ext = filename.split('.').pop()?.toLowerCase()
@@ -65,7 +61,7 @@ export async function uploadFile(file: File, path?: string): Promise<{ url: stri
 
   try {
     // Use direct Supabase upload (bypasses Netlify function size limits)
-    const supabase = createClient(supabaseUrl, supabaseAnonKey)
+    const supabase = getSupabaseBrowserClient()
 
     const { data, error } = await supabase.storage
       .from(bucket)

--- a/cboa-site/lib/storage/supabase.ts
+++ b/cboa-site/lib/storage/supabase.ts
@@ -102,7 +102,7 @@ export class SupabaseStorageAdapter implements StorageAdapter {
         .order('created_at', { ascending: false })
 
       if (!dbError && dbFiles && dbFiles.length > 0) {
-        return dbFiles.map(file => ({
+        return dbFiles.map((file: any) => ({
           id: file.id,
           fileName: file.file_name,
           originalName: file.original_name || file.file_name,
@@ -131,7 +131,7 @@ export class SupabaseStorageAdapter implements StorageAdapter {
       if (!data) return []
 
       // Map storage files to our format
-      return data.map(file => {
+      return data.map((file: any) => {
         const { data: { publicUrl } } = supabase.storage
           .from(this.bucket)
           .getPublicUrl(`${path}/${file.name}`)
@@ -165,7 +165,7 @@ export class SupabaseStorageAdapter implements StorageAdapter {
     try {
       const { data: buckets } = await supabase.storage.listBuckets()
       
-      if (!buckets?.find(b => b.name === this.bucket)) {
+      if (!buckets?.find((b: any) => b.name === this.bucket)) {
         const { error } = await supabase.storage.createBucket(this.bucket, {
           public: true,
           allowedMimeTypes: [

--- a/cboa-site/lib/storage/supabase.ts
+++ b/cboa-site/lib/storage/supabase.ts
@@ -1,11 +1,7 @@
-import { createClient } from '@supabase/supabase-js'
+import { getSupabaseBrowserClient } from '../api/client'
 import { StorageAdapter, FileUploadResult, StorageFile } from './interface'
 
-// Initialize Supabase client
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+const supabase = getSupabaseBrowserClient()
 
 export class SupabaseStorageAdapter implements StorageAdapter {
   private bucket: string

--- a/cboa-site/lib/supabase.ts
+++ b/cboa-site/lib/supabase.ts
@@ -1,21 +1,21 @@
 import { createClient } from '@supabase/supabase-js'
+import { getSupabaseBrowserClient } from './api/client'
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || ''
 
-// Client-side Supabase client (safe for browser use)
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
-
-// Server-side Supabase client (for Netlify Functions only)
-// Only initialize if service key is available (server-side only)
+// Server-side Supabase client (for Netlify Functions only). Only
+// initialize if the service key is available — this module is
+// imported by client code too, where the service key is undefined.
 export const supabaseAdmin = supabaseServiceKey
   ? createClient(supabaseUrl, supabaseServiceKey)
   : null
 
-// Type-safe table accessors for direct Supabase access
-export const publicNewsTable = () => supabase.from('public_news')
-export const publicTrainingTable = () => supabase.from('public_training_events')
-export const publicResourcesTable = () => supabase.from('public_resources')
-export const publicPagesTable = () => supabase.from('public_pages')
-export const officialsTable = () => supabase.from('officials')
+// Type-safe table accessors. These run client-side and use the
+// shared singleton browser client so we don't fan out into multiple
+// GoTrueClient instances.
+export const publicNewsTable = () => getSupabaseBrowserClient().from('public_news')
+export const publicTrainingTable = () => getSupabaseBrowserClient().from('public_training_events')
+export const publicResourcesTable = () => getSupabaseBrowserClient().from('public_resources')
+export const publicPagesTable = () => getSupabaseBrowserClient().from('public_pages')
+export const officialsTable = () => getSupabaseBrowserClient().from('officials')


### PR DESCRIPTION
## Summary

Closes audit #19. 13 distinct browser-side Supabase client instantiations → 1 singleton.

The "Multiple GoTrueClient instances detected" warning observed during the password-reset debugging session was the surface symptom; the real concern is auth-state desync — e.g. PasswordChangeModal updating a password through one client while AuthContext's onAuthStateChange listener owns a different in-memory session and never fires.

\`getSupabaseBrowserClient()\` is now exported from \`lib/api/client.ts\` and used by every consumer.

## Files changed

| File | Change |
|---|---|
| \`lib/api/client.ts\` | Promote internal \`getBrowserClient\` to exported \`getSupabaseBrowserClient\` |
| \`contexts/AuthContext.tsx\` | Use singleton |
| \`components/PasswordChangeModal.tsx\` | Use singleton |
| \`components/AuthErrorHandler.tsx\` | Use singleton |
| \`app/auth/{callback,set-password,complete-profile}/page.tsx\` | Use singleton |
| \`app/portal/admin/{logs,email-history,contact-submissions,osa-submissions}/page.tsx\` | Use singleton |
| \`lib/fileUpload.ts\`, \`lib/storage/supabase.ts\` | Use singleton |
| \`lib/supabase.ts\` | Drop unused browser \`supabase\` const; route table helpers through singleton; preserve server-side \`supabaseAdmin\` |

## Conflicts with other open PRs

This PR touches several files also touched by #40, #41, #43. The conflict zones are at the imports and module-top \`createBrowserClient(...)\` call — the *other* PRs' changes are in handlers/JSX further down. Resolution should be straightforward: keep the singleton import from this PR, keep the behavioral changes from the other PRs.

## Test plan

- [ ] No "Multiple GoTrueClient instances detected" warning in browser console after login
- [ ] Sign in → AuthContext sets user, all components see the same session
- [ ] PasswordChangeModal updates the password, AuthContext stays in sync
- [ ] All admin pages still load data with the existing Authorization header
- [ ] File uploads (lib/fileUpload, lib/storage/supabase) still work for both portal-resources and privileged buckets

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)