### PR TITLE
fix(auth): drop AuthContext sign-in redirect; login page owns it

### DIFF
--- a/cboa-site/contexts/AuthContext.tsx
+++ b/cboa-site/contexts/AuthContext.tsx
@@ -202,12 +202,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           // Sync user to members table on login
           syncUserToMembers(session.user)
 
-          // Only redirect if there's a stored redirect path (indicating a fresh login)
-          const redirectPath = sessionStorage.getItem('redirectAfterLogin')
-          if (redirectPath) {
-            sessionStorage.removeItem('redirectAfterLogin')
-            window.location.href = redirectPath
-          }
+          // Redirect intentionally NOT done here. The login page owns
+          // post-sign-in navigation via its own useEffect — having both
+          // fire on the same auth event caused intermittent flicker
+          // and duplicate history entries (audit #21).
         } else if (event === 'SIGNED_OUT') {
           clientLogger.info('auth', 'signed_out', 'User signed out')
           clientLogger.clearUser()


### PR DESCRIPTION
## Summary

Closes audit #21.

On SIGNED_IN, two redirects fired on the same auth event:
1. \`AuthContext.tsx:206-210\` did \`window.location.href\` (full reload)
2. \`app/(auth)/login/page.tsx:35-44\` did \`router.push\` (soft nav)

Symptoms: intermittent flicker, duplicate history entries, occasional landing on \`/portal\` even with a deep-link target.

Fix: remove the AuthContext side-effect redirect. The login page already handles post-sign-in navigation via its own useEffect that reads \`?redirect=\`. AuthContext should update state, not navigate.

## Conflicts with #40

PR #40 also touches \`app/(auth)/login/page.tsx\` (deletes the migrated-user fallback flow). This PR doesn't touch that file, so no direct conflict — but #40's modifications to \`login/page.tsx\` keep its useEffect-driven redirect intact, which is exactly what this PR delegates the redirect to.

## Test plan

- [ ] Sign in from \`/login\` → lands on \`/portal\` (default), no flicker, single history entry
- [ ] Visit \`/portal/news?id=abc\` while logged out → redirected to \`/login?redirect=…\` → after sign-in, lands on \`/portal/news?id=abc\`
- [ ] Sign in from \`/login?redirect=/portal/calendar\` → lands on \`/portal/calendar\` (single navigation)
- [ ] No "navigating from inside an unmounted component" warnings

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)