### PR TITLE
fix(build): enforce ESLint during production builds

### DIFF
--- a/cboa-site/next.config.js
+++ b/cboa-site/next.config.js
@@ -8,7 +8,12 @@ const nextConfig = {
   },
   trailingSlash: true,
   eslint: {
-    ignoreDuringBuilds: true,
+    // Lint errors fail the build. Previously this was `true`, which
+    // let regressions ship — including hook-deps mistakes and
+    // floating-promise bugs that should have been caught before merge.
+    // If a specific rule is too noisy for CI, address it via
+    // .eslintrc overrides rather than re-enabling this escape hatch.
+    ignoreDuringBuilds: false,
   },
   typescript: {
     ignoreBuildErrors: false,


### PR DESCRIPTION
## Summary

Closes audit #32. Flipped \`next.config.js\` \`eslint.ignoreDuringBuilds\` from \`true\` to \`false\`.

## Heads-up

This will surface the existing lint backlog in the Netlify deploy preview build for this PR. If the build fails, that's expected — review what comes out, and either:
1. Fix the specific issues, or
2. Add targeted overrides in \`.eslintrc\` for any rules that are too noisy to address right now

The audit explicitly recommended NOT re-enabling \`ignoreDuringBuilds\` as a workaround — the whole point is to catch regressions early.

If the lint backlog turns out to be substantial, this PR can be held until a follow-up cleans it up. The other 36 issues' PRs are independent.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)