### PR TITLE
feat(errors): standardize responses + friendly helper for end-user copy

### DIFF
--- a/cboa-site/app/auth/complete-profile/page.tsx
+++ b/cboa-site/app/auth/complete-profile/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, Suspense } from 'react'
 import { useRouter } from 'next/navigation'
 import { getSupabaseBrowserClient } from '@/lib/api/client'
+import { readFriendlyError, friendlyErrorFromThrown } from '@/lib/userFacingError'
 import { IconUser, IconLoader2, IconAlertCircle, IconCheck, IconPhone, IconHome, IconUserHeart } from '@tabler/icons-react'
 
 const PHONE_REGEX = /^\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/
@@ -198,15 +199,15 @@ function CompleteProfileForm() {
       })
 
       if (!response.ok) {
-        const data = await response.json()
-        throw new Error(data.error || 'Failed to update profile')
+        const friendly = await readFriendlyError(response)
+        throw new Error(friendly.message)
       }
 
       // Success - redirect to portal
       router.push('/portal')
-    } catch (err: any) {
+    } catch (err) {
       console.error('Profile update error:', err)
-      setError(err.message || 'An unexpected error occurred. Please try again.')
+      setError(friendlyErrorFromThrown(err).message)
     } finally {
       setIsLoading(false)
     }

--- a/cboa-site/app/portal/admin/contact-submissions/page.tsx
+++ b/cboa-site/app/portal/admin/contact-submissions/page.tsx
@@ -10,6 +10,7 @@ import {
   SortingState,
 } from '@tanstack/react-table'
 import { getSupabaseBrowserClient } from '@/lib/api/client'
+import { readFriendlyError, friendlyErrorFromThrown } from '@/lib/userFacingError'
 import { useAdminGuard } from '@/hooks/useAdminGuard'
 import {
   IconArrowUp,
@@ -291,15 +292,15 @@ export default function ContactSubmissionsPage() {
       })
 
       if (!response.ok) {
-        const data = await response.json()
-        throw new Error(data.error || 'Failed to fetch submissions')
+        const friendly = await readFriendlyError(response)
+        throw new Error(friendly.message)
       }
 
       const data = await response.json()
       setSubmissions(data.submissions)
       setPagination(data.pagination)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch submissions')
+      setError(friendlyErrorFromThrown(err).message)
     } finally {
       setLoading(false)
     }
@@ -319,7 +320,8 @@ export default function ContactSubmissionsPage() {
     })
 
     if (!response.ok) {
-      throw new Error('Failed to update submission')
+      const friendly = await readFriendlyError(response)
+      throw new Error(friendly.message)
     }
 
     await fetchSubmissions(pagination.page)

--- a/cboa-site/app/portal/admin/email-history/page.tsx
+++ b/cboa-site/app/portal/admin/email-history/page.tsx
@@ -10,6 +10,7 @@ import {
   SortingState,
 } from '@tanstack/react-table'
 import { getSupabaseBrowserClient } from '@/lib/api/client'
+import { readFriendlyError, friendlyErrorFromThrown } from '@/lib/userFacingError'
 import { useAdminGuard } from '@/hooks/useAdminGuard'
 import {
   IconArrowUp,
@@ -346,15 +347,15 @@ export default function EmailHistoryPage() {
       })
 
       if (!response.ok) {
-        const data = await response.json()
-        throw new Error(data.error || 'Failed to fetch email history')
+        const friendly = await readFriendlyError(response)
+        throw new Error(friendly.message)
       }
 
       const data = await response.json()
       setEmails(data.emails)
       setPagination(data.pagination)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch email history')
+      setError(friendlyErrorFromThrown(err).message)
     } finally {
       setLoading(false)
     }

--- a/cboa-site/app/portal/admin/logs/page.tsx
+++ b/cboa-site/app/portal/admin/logs/page.tsx
@@ -12,6 +12,7 @@ import {
   SortingState,
 } from '@tanstack/react-table'
 import { getSupabaseBrowserClient } from '@/lib/api/client'
+import { readFriendlyError, friendlyErrorFromThrown } from '@/lib/userFacingError'
 import { useAdminGuard } from '@/hooks/useAdminGuard'
 import {
   IconArrowUp,
@@ -134,8 +135,8 @@ export default function AdminLogsPage() {
       })
 
       if (!response.ok) {
-        const data = await response.json()
-        throw new Error(data.error || 'Failed to fetch logs')
+        const friendly = await readFriendlyError(response)
+        throw new Error(friendly.message)
       }
 
       const data = await response.json()
@@ -147,7 +148,7 @@ export default function AdminLogsPage() {
       }
       setPagination(data.pagination)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch logs')
+      setError(friendlyErrorFromThrown(err).message)
     } finally {
       setLoading(false)
     }

--- a/cboa-site/app/portal/admin/osa-submissions/page.tsx
+++ b/cboa-site/app/portal/admin/osa-submissions/page.tsx
@@ -10,6 +10,7 @@ import {
   SortingState,
 } from '@tanstack/react-table'
 import { getSupabaseBrowserClient } from '@/lib/api/client'
+import { readFriendlyError, friendlyErrorFromThrown } from '@/lib/userFacingError'
 import { useAdminGuard } from '@/hooks/useAdminGuard'
 import {
   IconArrowUp,
@@ -463,15 +464,15 @@ export default function OSASubmissionsPage() {
       })
 
       if (!response.ok) {
-        const data = await response.json()
-        throw new Error(data.error || 'Failed to fetch submissions')
+        const friendly = await readFriendlyError(response)
+        throw new Error(friendly.message)
       }
 
       const data = await response.json()
       setSubmissions(data.submissions)
       setPagination(data.pagination)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch submissions')
+      setError(friendlyErrorFromThrown(err).message)
     } finally {
       setLoading(false)
     }
@@ -491,7 +492,8 @@ export default function OSASubmissionsPage() {
     })
 
     if (!response.ok) {
-      throw new Error('Failed to update submission')
+      const friendly = await readFriendlyError(response)
+      throw new Error(friendly.message)
     }
 
     // Refresh the list

--- a/cboa-site/app/portal/mail/page.tsx
+++ b/cboa-site/app/portal/mail/page.tsx
@@ -7,6 +7,7 @@ import { IconSend, IconUsers, IconMail, IconCheck, IconAlertCircle, IconEye, Ico
 import { useToast } from '@/contexts/ToastContext'
 import { TinyMCEEditor } from '@/components/TinyMCEEditor'
 import { generateCBOAEmailTemplate } from '@/lib/emailTemplate'
+import { readFriendlyError, friendlyErrorFromThrown } from '@/lib/userFacingError'
 
 export default function MailPage() {
   const { user, getAccessToken } = useAuth()
@@ -305,12 +306,12 @@ export default function MailPage() {
         })
       })
 
-      const data = await response.json()
-
       if (!response.ok) {
-        throw new Error(data.error || 'Failed to send email')
+        const friendly = await readFriendlyError(response)
+        throw new Error(friendly.message)
       }
 
+      const data = await response.json()
       addToast(`Email sent successfully to ${data.recipientCount} recipients!`, 'success')
 
       // Save as announcement if checkbox is selected
@@ -333,9 +334,9 @@ export default function MailPage() {
       setContent('')
       setRankFilter('')
       setSaveAsAnnouncement(false)
-    } catch (error: any) {
+    } catch (error) {
       console.error('Error sending email:', error)
-      addToast(error.message || 'Failed to send email', 'error')
+      addToast(friendlyErrorFromThrown(error).message, 'error')
     } finally {
       setIsSending(false)
     }
@@ -360,7 +361,8 @@ export default function MailPage() {
     })
 
     if (!response.ok) {
-      throw new Error('Failed to save announcement')
+      const friendly = await readFriendlyError(response)
+      throw new Error(friendly.message)
     }
   }
 

--- a/cboa-site/components/PasswordChangeModal.tsx
+++ b/cboa-site/components/PasswordChangeModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { getSupabaseBrowserClient } from '@/lib/api/client'
+import { friendlyErrorFromThrown } from '@/lib/userFacingError'
 import { IconLock, IconLoader2, IconAlertCircle, IconCheck, IconX } from '@tabler/icons-react'
 
 interface PasswordChangeModalProps {
@@ -57,8 +58,8 @@ export default function PasswordChangeModal({ isOpen, onClose, onSuccess, userEm
       }
 
       onSuccess()
-    } catch (err: any) {
-      setError(err.message || 'Failed to update password')
+    } catch (err) {
+      setError(friendlyErrorFromThrown(err).message)
     } finally {
       setIsLoading(false)
     }

--- a/cboa-site/components/forms/ContactForm.tsx
+++ b/cboa-site/components/forms/ContactForm.tsx
@@ -9,6 +9,7 @@ import Link from 'next/link'
 import Button from '@/components/ui/Button'
 import { IconSend, IconCheck, IconAlertCircle, IconBulb, IconX, IconShieldCheck, IconMail, IconQuestionMark, IconLink, IconChevronDown, IconPlus, IconTrash } from '@tabler/icons-react'
 import { isDeviceFlagged } from '@/lib/deviceFlag'
+import { readFriendlyError, friendlyErrorFromThrown, toFriendlyMessage } from '@/lib/userFacingError'
 
 // Pattern detection for suggesting the right form
 type FormSuggestion = {
@@ -283,17 +284,19 @@ export default function ContactForm() {
         body: JSON.stringify({ email: watchedEmail }),
       })
 
-      const result = await response.json()
-
       if (!response.ok) {
-        throw new Error(result.error || 'Failed to send verification code')
+        const friendly = await readFriendlyError(response)
+        setVerificationStatus('error')
+        setVerificationError(friendly.message)
+        return
       }
 
+      const result = await response.json()
       setVerificationToken(result.token)
       setVerificationStatus('sent')
     } catch (error) {
       setVerificationStatus('error')
-      setVerificationError(error instanceof Error ? error.message : 'Failed to send verification code.')
+      setVerificationError(friendlyErrorFromThrown(error).message)
     }
   }
 
@@ -363,15 +366,24 @@ export default function ContactForm() {
         body: JSON.stringify(payload),
       })
 
-      const result = await response.json()
-
       if (!response.ok) {
-        // If server suggests a corrected email (typo detection), apply it and show message
-        if (result.suggestion) {
-          setValue('email', result.suggestion)
-          throw new Error(`${result.error} We've corrected it for you — please review and resubmit.`)
+        let body: { suggestion?: string; error?: string; message?: string; fields?: Record<string, string> } = {}
+        try {
+          body = await response.json()
+        } catch {
+          // Non-JSON body — leave empty.
         }
-        throw new Error(result.error || 'Failed to send message')
+        if (body.suggestion) {
+          setValue('email', body.suggestion)
+        }
+        const friendly = toFriendlyMessage(response, body)
+        setSubmitStatus('error')
+        setErrorMessage(
+          body.suggestion
+            ? `${friendly.message} We’ve filled in the corrected address — please review and resubmit.`
+            : friendly.message,
+        )
+        return
       }
 
       setSubmitStatus('success')
@@ -391,7 +403,7 @@ export default function ContactForm() {
       setVerificationCode('')
     } catch (error) {
       setSubmitStatus('error')
-      setErrorMessage(error instanceof Error ? error.message : 'Failed to send message. Please try again.')
+      setErrorMessage(friendlyErrorFromThrown(error).message)
     }
   }
 
@@ -715,15 +727,18 @@ export default function ContactForm() {
                                 code: val,
                               }),
                             })
-                            const result = await res.json()
-                            if (res.ok && result.valid) {
-                              setVerificationError('')
-                              setVerificationStatus('verified')
-                            } else {
-                              setVerificationError(result.error || 'Incorrect code. Please check the email and try again.')
+                            if (res.ok) {
+                              const result = await res.json()
+                              if (result.valid) {
+                                setVerificationError('')
+                                setVerificationStatus('verified')
+                                return
+                              }
                             }
-                          } catch {
-                            setVerificationError('Could not verify the code. Please try again.')
+                            const friendly = await readFriendlyError(res)
+                            setVerificationError(friendly.message)
+                          } catch (err) {
+                            setVerificationError(friendlyErrorFromThrown(err).message)
                           }
                         }
                       }}

--- a/cboa-site/components/forms/OSARequestFormWizard.tsx
+++ b/cboa-site/components/forms/OSARequestFormWizard.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/navigation'
 import Card from '@/components/ui/Card'
 import Button from '@/components/ui/Button'
 import { IconCheck, IconAlertCircle, IconLoader2, IconArrowLeft, IconArrowRight } from '@tabler/icons-react'
+import { readFriendlyError, friendlyErrorFromThrown } from '@/lib/userFacingError'
 
 // Import wizard components
 import ProgressIndicator from './wizard/ProgressIndicator'
@@ -547,15 +548,20 @@ export default function OSARequestFormWizard() {
       })
 
       if (!response.ok) {
-        const errorData = await response.json()
-        throw new Error(errorData.error || 'Failed to submit form')
+        const friendly = await readFriendlyError(response)
+        setSubmitError(friendly.message)
+        setIsSubmitting(false)
+        // Jump to review step so the user sees the banner
+        if (currentStep !== 5) setCurrentStep(5)
+        return
       }
 
       clearStorage()
       router.push('/get-officials/success')
     } catch (error) {
       console.error('Form submission error:', error)
-      setSubmitError(error instanceof Error ? error.message : 'An unexpected error occurred. Please try again.')
+      setSubmitError(friendlyErrorFromThrown(error).message)
+      if (currentStep !== 5) setCurrentStep(5)
     } finally {
       setIsSubmitting(false)
     }

--- a/cboa-site/components/portal/MemberRegistration.tsx
+++ b/cboa-site/components/portal/MemberRegistration.tsx
@@ -8,6 +8,7 @@ import { membersAPI } from '@/lib/api'
 import { IconUser, IconPhone, IconHome, IconAlertCircle, IconLogout } from '@tabler/icons-react'
 import { memberRegistrationSchema, type MemberRegistrationFormData } from '@/lib/schemas'
 import { PROVINCES } from '@/lib/constants'
+import { friendlyErrorFromThrown } from '@/lib/userFacingError'
 
 interface MemberRegistrationProps {
   onComplete: () => void
@@ -83,9 +84,9 @@ export default function MemberRegistration({ onComplete }: MemberRegistrationPro
       }
 
       onComplete()
-    } catch (err: any) {
+    } catch (err) {
       console.error('Registration error:', err)
-      setError(err.message || 'Failed to complete registration. Please try again.')
+      setError(friendlyErrorFromThrown(err).message)
     } finally {
       setIsSubmitting(false)
     }

--- a/cboa-site/lib/api/client.ts
+++ b/cboa-site/lib/api/client.ts
@@ -2,6 +2,7 @@
  * Shared API client utilities — auth headers, fetch wrapper, config.
  */
 import { retryAsync, parseAPIError, AppError } from '../errorHandling'
+import { toFriendlyMessage, type ServerErrorBody } from '../userFacingError'
 import { createBrowserClient } from '@supabase/ssr'
 
 export { AppError }
@@ -62,21 +63,26 @@ export async function apiFetch(url: string, options?: RequestInit): Promise<Resp
     })
 
     if (!response.ok) {
-      let errorMessage = `Request failed with status ${response.status}`
+      let body: ServerErrorBody | null = null
       try {
-        const errorData = await response.json()
-        errorMessage = errorData.error || errorData.message || errorMessage
+        body = await response.json()
       } catch {
-        // If JSON parsing fails, use default message
+        // Non-JSON body — fall through to status-based default.
       }
-
-      throw new AppError(errorMessage, 'API_ERROR', response.status)
+      const friendly = toFriendlyMessage(response, body)
+      throw new AppError(friendly.message, body?.error || 'API_ERROR', response.status, {
+        fields: friendly.fields,
+        code: body?.error,
+      })
     }
 
     return response
   } catch (error: any) {
     if (error.name === 'TypeError' && error.message === 'Failed to fetch') {
-      throw new AppError('Network error. Please check your internet connection.', 'NETWORK_ERROR')
+      throw new AppError(
+        'We couldn’t reach the server. Please check your internet connection and try again.',
+        'NETWORK_ERROR',
+      )
     }
     if (error instanceof AppError) throw error
     throw new AppError(parseAPIError(error), 'UNKNOWN_ERROR')

--- a/cboa-site/lib/userFacingError.ts
+++ b/cboa-site/lib/userFacingError.ts
@@ -1,0 +1,145 @@
+/**
+ * Map server / network errors to calm, user-safe copy.
+ *
+ * Every code path that surfaces an error to a user (toast, banner, inline)
+ * should route through `toFriendlyMessage` or `readFriendlyError` so that
+ * customers never see raw `Failed to fetch`, supabase internals, env-var
+ * names, or stack traces.
+ *
+ * The server side (netlify/functions/_shared/errorResponse.ts) emits
+ * `{ error: code, message?, fields? }`. This module decodes that shape.
+ */
+
+export interface FriendlyError {
+  /** Calm, plain-language sentence to show the user. */
+  message: string
+  /** Field-level validation errors, keyed by field name. */
+  fields?: Record<string, string>
+  /** The original error code from the server, if any (machine-readable). */
+  code?: string
+}
+
+export interface ServerErrorBody {
+  error?: string
+  message?: string
+  fields?: Record<string, string>
+  [key: string]: unknown
+}
+
+const GENERIC_MESSAGE =
+  'Something went wrong on our end — please try again, or contact us if the problem persists.'
+
+const STATUS_DEFAULTS: Record<number, string> = {
+  400: 'That request didn’t look right. Please check your input and try again.',
+  401: 'Please sign in to continue.',
+  403: 'You don’t have permission to do that.',
+  404: 'We couldn’t find what you were looking for.',
+  405: 'That action is not allowed.',
+  408: 'The request timed out. Please try again.',
+  409: 'That doesn’t match the current state — please refresh and try again.',
+  413: 'That file is too large to upload.',
+  422: 'Please check the highlighted fields and try again.',
+  429: 'You’re going a bit fast — please wait a minute and try again.',
+  500: GENERIC_MESSAGE,
+  502: 'We couldn’t reach a service we depend on. Please try again shortly.',
+  503: 'We couldn’t reach a service we depend on. Please try again shortly.',
+  504: 'We couldn’t reach a service we depend on. Please try again shortly.',
+}
+
+const CODE_DEFAULTS: Record<string, string> = {
+  bad_request: 'That request didn’t look right. Please check your input and try again.',
+  invalid_input: 'Please check the highlighted fields and try again.',
+  unauthorized: 'Please sign in to continue.',
+  forbidden: 'You don’t have permission to do that.',
+  not_found: 'We couldn’t find what you were looking for.',
+  method_not_allowed: 'That action is not allowed here.',
+  rate_limited: 'You’re going a bit fast — please wait a minute and try again.',
+  email_unavailable: 'That email address looks invalid. Please double-check and try again.',
+  verification_required: 'Please verify your email address before submitting.',
+  verification_failed: 'That verification code didn’t match. Please check the email and try again.',
+  service_unavailable: 'We couldn’t reach a service we depend on. Please try again in a few minutes.',
+  server_error: GENERIC_MESSAGE,
+}
+
+function isFriendlyText(value: unknown): value is string {
+  if (typeof value !== 'string') return false
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return false
+  // Reject codes (no spaces, all-lowercase or snake_case) — keep them as codes.
+  if (/^[a-z][a-z0-9_]*$/.test(trimmed) && !trimmed.includes(' ')) return false
+  return true
+}
+
+/**
+ * Map a fetch Response + parsed JSON body to a friendly error.
+ * Prefers (in order): server-provided `message`, code-based default,
+ * status-based default, generic fallback.
+ */
+export function toFriendlyMessage(
+  response: Response | { status: number } | null,
+  body: ServerErrorBody | null | undefined,
+): FriendlyError {
+  const code = typeof body?.error === 'string' ? body.error : undefined
+  const fields = body?.fields
+
+  if (body && isFriendlyText(body.message)) {
+    return { message: body.message!.trim(), fields, code }
+  }
+
+  if (code && CODE_DEFAULTS[code]) {
+    return { message: CODE_DEFAULTS[code], fields, code }
+  }
+
+  // Some legacy endpoints still put a free-text sentence in `error`.
+  // If it looks like a sentence (has spaces, isn't a snake_case code), use it.
+  if (code && isFriendlyText(code)) {
+    return { message: code, fields, code: undefined }
+  }
+
+  if (response && STATUS_DEFAULTS[response.status]) {
+    return { message: STATUS_DEFAULTS[response.status], fields, code }
+  }
+
+  return { message: GENERIC_MESSAGE, fields, code }
+}
+
+/**
+ * Read a fetch Response and produce a friendly error. Safe to call on
+ * non-JSON bodies — falls back to the status-code default.
+ */
+export async function readFriendlyError(response: Response): Promise<FriendlyError> {
+  let body: ServerErrorBody | null = null
+  try {
+    body = await response.json()
+  } catch {
+    // Body is empty or not JSON — fall through.
+  }
+  return toFriendlyMessage(response, body)
+}
+
+/**
+ * Map a thrown error (typically from `fetch` itself or an AppError) to
+ * a friendly message. Use this in catch blocks where the request never
+ * produced a Response.
+ */
+export function friendlyErrorFromThrown(error: unknown): FriendlyError {
+  if (error instanceof TypeError && /failed to fetch|network/i.test(error.message)) {
+    return {
+      message:
+        'We couldn’t reach the server. Please check your internet connection and try again.',
+    }
+  }
+  if (typeof error === 'object' && error !== null) {
+    const e = error as { code?: string; statusCode?: number; message?: string; fields?: Record<string, string> }
+    if (e.code && CODE_DEFAULTS[e.code]) {
+      return { message: CODE_DEFAULTS[e.code], fields: e.fields, code: e.code }
+    }
+    if (typeof e.statusCode === 'number' && STATUS_DEFAULTS[e.statusCode]) {
+      return { message: STATUS_DEFAULTS[e.statusCode], fields: e.fields, code: e.code }
+    }
+    if (isFriendlyText(e.message)) {
+      return { message: e.message!.trim(), fields: e.fields, code: e.code }
+    }
+  }
+  return { message: GENERIC_MESSAGE }
+}

--- a/cboa-site/netlify/functions/_shared/errorResponse.ts
+++ b/cboa-site/netlify/functions/_shared/errorResponse.ts
@@ -1,0 +1,93 @@
+/**
+ * Standardized error responses for Netlify functions.
+ *
+ * The body shape is { error: ErrorCode, message?: string, fields?: Record<string,string> }
+ * where `error` is a stable machine-readable code and `message` is a calm,
+ * user-safe message. Internal details (stack traces, env-var names, supabase
+ * internals) MUST NOT be put in `message` — log them via Logger.error instead.
+ *
+ * Match this on the client with lib/userFacingError.ts to render friendly copy.
+ */
+
+export type ErrorCode =
+  | 'bad_request'
+  | 'invalid_input'
+  | 'unauthorized'
+  | 'forbidden'
+  | 'not_found'
+  | 'method_not_allowed'
+  | 'rate_limited'
+  | 'email_unavailable'
+  | 'verification_required'
+  | 'verification_failed'
+  | 'service_unavailable'
+  | 'server_error'
+
+const STATUS: Record<ErrorCode, number> = {
+  bad_request: 400,
+  invalid_input: 400,
+  unauthorized: 401,
+  forbidden: 403,
+  not_found: 404,
+  method_not_allowed: 405,
+  rate_limited: 429,
+  email_unavailable: 400,
+  verification_required: 400,
+  verification_failed: 400,
+  service_unavailable: 503,
+  server_error: 500,
+}
+
+/** Calm, user-safe defaults for each code. */
+const DEFAULT_MESSAGE: Record<ErrorCode, string> = {
+  bad_request: 'That request didn’t look right. Please check your input and try again.',
+  invalid_input: 'Please check the highlighted fields and try again.',
+  unauthorized: 'Please sign in to continue.',
+  forbidden: 'You don’t have permission to do that.',
+  not_found: 'We couldn’t find what you were looking for.',
+  method_not_allowed: 'That action is not allowed here.',
+  rate_limited: 'You’re going a bit fast — please wait a minute and try again.',
+  email_unavailable: 'That email address looks invalid. Please double-check and try again.',
+  verification_required: 'Please verify your email address before submitting.',
+  verification_failed: 'That verification code didn’t match. Please check the email and try again.',
+  service_unavailable: 'We couldn’t reach a service we depend on. Please try again in a few minutes.',
+  server_error: 'Something went wrong on our end — please try again, or contact us if the problem persists.',
+}
+
+export interface ErrorResponseInit {
+  code: ErrorCode
+  /** Override the default user-safe message. Keep it calm and actionable. */
+  message?: string
+  /** Field-level validation errors, keyed by field name. */
+  fields?: Record<string, string>
+  /** Headers to attach to the response. */
+  headers?: Record<string, string>
+  /** Override the default HTTP status for this code. */
+  statusCode?: number
+  /** Extra body keys (e.g. `suggestion` for typo correction). */
+  extra?: Record<string, unknown>
+}
+
+export interface NetlifyHandlerResponse {
+  statusCode: number
+  body: string
+  headers: Record<string, string>
+}
+
+export function errorResponse(init: ErrorResponseInit): NetlifyHandlerResponse {
+  const body: Record<string, unknown> = {
+    error: init.code,
+    message: init.message ?? DEFAULT_MESSAGE[init.code],
+  }
+  if (init.fields) body.fields = init.fields
+  if (init.extra) {
+    for (const [k, v] of Object.entries(init.extra)) {
+      if (k !== 'error' && k !== 'message' && k !== 'fields') body[k] = v
+    }
+  }
+  return {
+    statusCode: init.statusCode ?? STATUS[init.code],
+    headers: init.headers ?? {},
+    body: JSON.stringify(body),
+  }
+}

--- a/cboa-site/netlify/functions/_shared/handler.ts
+++ b/cboa-site/netlify/functions/_shared/handler.ts
@@ -20,6 +20,9 @@ import { Handler, HandlerEvent, HandlerContext as NetlifyContext } from '@netlif
 import { createClient, SupabaseClient } from '@supabase/supabase-js'
 import { Logger } from '../../../lib/logger'
 import { SITE_URL } from '../../../lib/siteConfig'
+import { errorResponse } from './errorResponse'
+export { errorResponse } from './errorResponse'
+export type { ErrorCode } from './errorResponse'
 
 // ---------------------------------------------------------------------------
 // Shared Supabase admin client (service role — used by all functions)
@@ -231,11 +234,7 @@ export function createHandler(options: CreateHandlerOptions): Handler {
 
     // --- Method check ---
     if (!allowedMethods.includes(event.httpMethod as HttpMethod)) {
-      return {
-        statusCode: 405,
-        headers: corsHeaders,
-        body: JSON.stringify({ error: 'Method not allowed' })
-      }
+      return errorResponse({ code: 'method_not_allowed', headers: corsHeaders })
     }
 
     // --- Auth ---
@@ -245,22 +244,14 @@ export function createHandler(options: CreateHandlerOptions): Handler {
     if (authLevel !== 'public') {
       const authHeader = event.headers.authorization || event.headers.Authorization
       if (!authHeader?.startsWith('Bearer ')) {
-        return {
-          statusCode: 401,
-          headers: corsHeaders,
-          body: JSON.stringify({ error: 'Unauthorized' })
-        }
+        return errorResponse({ code: 'unauthorized', headers: corsHeaders })
       }
 
       const token = authHeader.replace('Bearer ', '')
       const { data: { user: authUser }, error: authError } = await supabase.auth.getUser(token)
 
       if (authError || !authUser) {
-        return {
-          statusCode: 401,
-          headers: corsHeaders,
-          body: JSON.stringify({ error: 'Unauthorized' })
-        }
+        return errorResponse({ code: 'unauthorized', headers: corsHeaders })
       }
 
       const role = getUserRole(authUser)
@@ -272,11 +263,7 @@ export function createHandler(options: CreateHandlerOptions): Handler {
       }
 
       if (!isAuthorized(role, authLevel)) {
-        return {
-          statusCode: 403,
-          headers: corsHeaders,
-          body: JSON.stringify({ error: 'Forbidden' })
-        }
+        return errorResponse({ code: 'forbidden', headers: corsHeaders })
       }
     }
 
@@ -295,11 +282,7 @@ export function createHandler(options: CreateHandlerOptions): Handler {
         `${name} API error`,
         error instanceof Error ? error : new Error(String(error))
       )
-      return {
-        statusCode: 500,
-        headers: corsHeaders,
-        body: JSON.stringify({ error: 'Internal server error' })
-      }
+      return errorResponse({ code: 'server_error', headers: corsHeaders })
     }
   }
 }

--- a/cboa-site/netlify/functions/accept-invite.ts
+++ b/cboa-site/netlify/functions/accept-invite.ts
@@ -1,5 +1,5 @@
 import { Handler } from '@netlify/functions'
-import { supabase as supabaseAdmin, getCorsHeaders } from './_shared/handler'
+import { supabase as supabaseAdmin, getCorsHeaders, errorResponse } from './_shared/handler'
 import { Logger } from '../../lib/logger'
 import { ORG_SHORT_NAME, getAuthCallbackUrl } from '../../lib/siteConfig'
 
@@ -31,14 +31,11 @@ export const handler: Handler = async (event) => {
 
   if (!token) {
     logger.warn('invite', 'missing_token', 'Accept invite called without token')
-    return {
-      statusCode: 400,
+    return errorResponse({
+      code: 'invalid_input',
       headers,
-      body: JSON.stringify({
-        error: 'Missing invite token',
-        message: 'No invite token provided. Please use the link from your email.'
-      })
-    }
+      message: 'No invite token provided. Please use the link from your email.',
+    })
   }
 
   try {
@@ -51,14 +48,11 @@ export const handler: Handler = async (event) => {
 
     if (tokenError || !inviteToken) {
       logger.warn('invite', 'invalid_token', `Invalid invite token: ${token.substring(0, 8)}...`)
-      return {
-        statusCode: 404,
+      return errorResponse({
+        code: 'not_found',
         headers,
-        body: JSON.stringify({
-          error: 'Invalid invite token',
-          message: 'This invite link is not valid. Please request a new invite from our website.'
-        })
-      }
+        message: 'This invite link is not valid. Please request a new invite from our website.',
+      })
     }
 
     // Atomically claim the token. If used_at was already set, no row is
@@ -75,15 +69,12 @@ export const handler: Handler = async (event) => {
 
     if (claimError || !claimedToken) {
       logger.info('invite', 'token_already_used', `Token already used for ${inviteToken.email}`)
-      return {
-        statusCode: 400,
+      return errorResponse({
+        code: 'invalid_input',
         headers,
-        body: JSON.stringify({
-          error: 'Invite already used',
-          message: 'This invite has already been used. If you need to reset your password, use the login page.',
-          alreadyUsed: true
-        })
-      }
+        message: 'This invite has already been used. If you need to reset your password, use the login page.',
+        extra: { alreadyUsed: true },
+      })
     }
 
     // Verify the member still exists and is active
@@ -95,26 +86,20 @@ export const handler: Handler = async (event) => {
 
     if (memberError || !member) {
       logger.warn('invite', 'member_not_found', `Member not found for token: ${inviteToken.email}`)
-      return {
-        statusCode: 404,
+      return errorResponse({
+        code: 'not_found',
         headers,
-        body: JSON.stringify({
-          error: 'Member not found',
-          message: `Your membership could not be found. Please contact ${ORG_SHORT_NAME} for assistance.`
-        })
-      }
+        message: `Your membership couldn’t be found. Please contact ${ORG_SHORT_NAME} for assistance.`,
+      })
     }
 
     if (member.status !== 'active') {
       logger.warn('invite', 'member_inactive', `Inactive member tried to accept invite: ${inviteToken.email}`)
-      return {
-        statusCode: 403,
+      return errorResponse({
+        code: 'forbidden',
         headers,
-        body: JSON.stringify({
-          error: 'Membership inactive',
-          message: `Your membership is not currently active. Please contact ${ORG_SHORT_NAME} for assistance.`
-        })
-      }
+        message: `Your membership is not currently active. Please contact ${ORG_SHORT_NAME} for assistance.`,
+      })
     }
 
     // Check if user already exists in auth (by email, not just member.user_id)
@@ -144,15 +129,12 @@ export const handler: Handler = async (event) => {
 
     if (authUser?.last_sign_in_at) {
       logger.info('invite', 'already_active_account', `User already has active account: ${inviteToken.email}`)
-      return {
-        statusCode: 400,
+      return errorResponse({
+        code: 'invalid_input',
         headers,
-        body: JSON.stringify({
-          error: 'Account already active',
-          message: 'Your account is already set up. Please use "Forgot Password" on the login page if you need to reset your password.',
-          alreadyActive: true
-        })
-      }
+        message: 'Your account is already set up. Please use "Forgot Password" on the login page if you need to reset your password.',
+        extra: { alreadyActive: true },
+      })
     }
 
     // User exists but never signed in - delete to recreate with fresh invite
@@ -182,14 +164,11 @@ export const handler: Handler = async (event) => {
 
     if (linkError) {
       logger.error('invite', 'link_generation_failed', `Failed to generate link for ${inviteToken.email}`, new Error(linkError.message))
-      return {
-        statusCode: 500,
+      return errorResponse({
+        code: 'service_unavailable',
         headers,
-        body: JSON.stringify({
-          error: 'Failed to generate invite',
-          message: 'Unable to process your invite. Please try again or request a new invite.'
-        })
-      }
+        message: 'We couldn’t process your invite. Please try again or request a new invite.',
+      })
     }
 
     // Update member's user_id
@@ -219,13 +198,10 @@ export const handler: Handler = async (event) => {
 
   } catch (error) {
     logger.error('invite', 'accept_invite_error', 'Error processing invite', error instanceof Error ? error : new Error(String(error)))
-    return {
-      statusCode: 500,
+    return errorResponse({
+      code: 'server_error',
       headers,
-      body: JSON.stringify({
-        error: 'Internal error',
-        message: 'An error occurred processing your invite. Please try again.'
-      })
-    }
+      message: 'Something went wrong processing your invite. Please try again, or contact us if the problem persists.',
+    })
   }
 }

--- a/cboa-site/netlify/functions/announcements.ts
+++ b/cboa-site/netlify/functions/announcements.ts
@@ -1,4 +1,4 @@
-import { createHandler, supabase } from './_shared/handler'
+import { createHandler, supabase, errorResponse } from './_shared/handler'
 
 export const handler = createHandler({
   name: 'announcements',
@@ -55,10 +55,10 @@ export const handler = createHandler({
         const { id, ...updateData } = body
 
         if (!id) {
-          return {
-            statusCode: 400,
-            body: JSON.stringify({ error: 'ID is required for update' })
-          }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'An announcement must be selected for update.',
+          })
         }
 
         logger.info('crud', 'update_announcement', `Updating announcement ${id}`, {
@@ -90,10 +90,10 @@ export const handler = createHandler({
         const { id } = event.queryStringParameters || {}
 
         if (!id) {
-          return {
-            statusCode: 400,
-            body: JSON.stringify({ error: 'ID is required for deletion' })
-          }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'An announcement must be selected for deletion.',
+          })
         }
 
         logger.info('crud', 'delete_announcement', `Deleting announcement ${id}`, {
@@ -120,10 +120,7 @@ export const handler = createHandler({
       }
 
       default:
-        return {
-          statusCode: 405,
-          body: JSON.stringify({ error: 'Method not allowed' })
-        }
+        return errorResponse({ code: 'method_not_allowed' })
     }
   }
 })

--- a/cboa-site/netlify/functions/auth-password-reset.ts
+++ b/cboa-site/netlify/functions/auth-password-reset.ts
@@ -1,5 +1,5 @@
 import { Handler } from '@netlify/functions'
-import { supabase as supabaseAdmin, getCorsHeaders } from './_shared/handler'
+import { supabase as supabaseAdmin, getCorsHeaders, errorResponse } from './_shared/handler'
 import { checkRateLimit, getClientIp } from './_shared/rateLimit'
 import { Logger } from '../../lib/logger'
 import { recordPasswordResetEmail } from '../../lib/emailHistory'
@@ -145,15 +145,11 @@ export const handler: Handler = async (event) => {
   // Rate limit: 3 reset requests per minute per IP
   const clientIp = getClientIp(event.headers)
   if (checkRateLimit(clientIp, { maxRequests: 3, windowMs: 60_000, prefix: 'pwd-reset' })) {
-    return { statusCode: 429, headers, body: JSON.stringify({ error: 'Too many requests. Please try again later.' }) }
+    return errorResponse({ code: 'rate_limited', headers })
   }
 
   if (event.httpMethod !== 'POST') {
-    return {
-      statusCode: 405,
-      headers,
-      body: JSON.stringify({ error: 'Method not allowed' })
-    }
+    return errorResponse({ code: 'method_not_allowed', headers })
   }
 
   try {
@@ -163,20 +159,18 @@ export const handler: Handler = async (event) => {
     })
 
     if (!email) {
-      return {
-        statusCode: 400,
+      return errorResponse({
+        code: 'invalid_input',
         headers,
-        body: JSON.stringify({ error: 'Email is required' })
-      }
+        message: 'Please enter your email address.',
+        fields: { email: 'Email is required' },
+      })
     }
 
     // Check if Microsoft Graph is configured
     if (!process.env.MICROSOFT_TENANT_ID || !process.env.MICROSOFT_CLIENT_ID || !process.env.MICROSOFT_CLIENT_SECRET) {
-      return {
-        statusCode: 500,
-        headers,
-        body: JSON.stringify({ error: 'Email service not configured' })
-      }
+      logger.error('auth', 'password_reset_config_error', 'Microsoft Graph credentials not configured')
+      return errorResponse({ code: 'service_unavailable', headers })
     }
 
     // Check if user exists
@@ -222,11 +216,11 @@ export const handler: Handler = async (event) => {
       // The user has been confirmed to exist by this point, so the
       // user-existence enumeration concern is already handled above.
       // Surface the failure loudly so the UI can show a real error.
-      return {
-        statusCode: 500,
+      return errorResponse({
+        code: 'service_unavailable',
         headers,
-        body: JSON.stringify({ error: 'Failed to send reset email. Please try again.' })
-      }
+        message: 'We couldn’t send a reset email right now. Please try again in a few minutes.',
+      })
     }
 
     // Send email via Microsoft Graph
@@ -269,10 +263,6 @@ export const handler: Handler = async (event) => {
 
   } catch (error) {
     logger.error('auth', 'password_reset_error', 'Password reset error', error instanceof Error ? error : new Error(String(error)))
-    return {
-      statusCode: 500,
-      headers,
-      body: JSON.stringify({ error: 'Failed to process request' })
-    }
+    return errorResponse({ code: 'server_error', headers })
   }
 }

--- a/cboa-site/netlify/functions/backfill-excel.ts
+++ b/cboa-site/netlify/functions/backfill-excel.ts
@@ -4,7 +4,7 @@
  * Requires admin auth token.
  * DELETE THIS FUNCTION after use.
  */
-import { createHandler, supabase } from './_shared/handler'
+import { createHandler, supabase, errorResponse } from './_shared/handler'
 import { osaExcelSync, type OSASubmissionData } from '../../lib/excel-sync'
 
 export const handler = createHandler({
@@ -13,7 +13,10 @@ export const handler = createHandler({
   auth: 'admin',
   handler: async ({ logger }) => {
     if (!osaExcelSync.isConfigured()) {
-      return { statusCode: 400, body: JSON.stringify({ error: 'Excel sync not configured' }) }
+      return errorResponse({
+        code: 'service_unavailable',
+        message: 'Excel sync is not currently available. Please contact a site administrator.',
+      })
     }
 
     // Fetch all submissions

--- a/cboa-site/netlify/functions/bulk-set-roles.ts
+++ b/cboa-site/netlify/functions/bulk-set-roles.ts
@@ -9,7 +9,7 @@
  */
 
 import { Handler } from '@netlify/functions'
-import { getCorsHeaders } from './_shared/handler'
+import { getCorsHeaders, errorResponse } from './_shared/handler'
 
 interface UserRecord {
   id: string
@@ -36,7 +36,7 @@ export const handler: Handler = async (event) => {
   }
 
   if (event.httpMethod !== 'POST') {
-    return { statusCode: 405, headers, body: JSON.stringify({ error: 'Method Not Allowed' }) }
+    return errorResponse({ code: 'method_not_allowed', headers })
   }
 
   const SITE_URL = process.env.URL || process.env.SITE_URL || 'https://cboa.ca'
@@ -60,7 +60,7 @@ export const handler: Handler = async (event) => {
     }
 
     if (!token) {
-      return { statusCode: 401, headers, body: JSON.stringify({ error: 'Unauthorized - JWT token required' }) }
+      return errorResponse({ code: 'unauthorized', headers })
     }
 
     // Fetch all users
@@ -130,6 +130,7 @@ export const handler: Handler = async (event) => {
       })
     }
   } catch (error: any) {
-    return { statusCode: 500, headers, body: JSON.stringify({ error: 'Internal server error' }) }
+    console.error('[BulkSetRoles] Error:', error)
+    return errorResponse({ code: 'server_error', headers })
   }
 }

--- a/cboa-site/netlify/functions/calendar-events.ts
+++ b/cboa-site/netlify/functions/calendar-events.ts
@@ -1,4 +1,4 @@
-import { createHandler, supabase } from './_shared/handler'
+import { createHandler, supabase, errorResponse } from './_shared/handler'
 
 export const handler = createHandler({
   name: 'calendar-events',
@@ -51,10 +51,10 @@ export const handler = createHandler({
         const { id, ...updateData } = body
 
         if (!id) {
-          return {
-            statusCode: 400,
-            body: JSON.stringify({ error: 'ID is required for update' })
-          }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A calendar event must be selected for update.',
+          })
         }
 
         logger.info('crud', 'update_calendar_event', `Updating event ${id}`, {
@@ -86,10 +86,10 @@ export const handler = createHandler({
         const { id } = event.queryStringParameters || {}
 
         if (!id) {
-          return {
-            statusCode: 400,
-            body: JSON.stringify({ error: 'ID is required for deletion' })
-          }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A calendar event must be selected for deletion.',
+          })
         }
 
         logger.info('crud', 'delete_calendar_event', `Deleting event ${id}`, { metadata: { id } })
@@ -114,7 +114,7 @@ export const handler = createHandler({
       }
 
       default:
-        return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) }
+        return errorResponse({ code: 'method_not_allowed' })
     }
   }
 })

--- a/cboa-site/netlify/functions/client-logs.ts
+++ b/cboa-site/netlify/functions/client-logs.ts
@@ -1,5 +1,5 @@
 import { Handler } from '@netlify/functions'
-import { getCorsHeaders, supabase } from './_shared/handler'
+import { getCorsHeaders, supabase, errorResponse } from './_shared/handler'
 import { checkRateLimit, getClientIp } from './_shared/rateLimit'
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
@@ -37,22 +37,14 @@ export const handler: Handler = async (event) => {
 
   // Only accept POST requests
   if (event.httpMethod !== 'POST') {
-    return {
-      statusCode: 405,
-      headers,
-      body: JSON.stringify({ error: 'Method not allowed' }),
-    }
+    return errorResponse({ code: 'method_not_allowed', headers })
   }
 
   // Rate limit per IP. Without this, the public endpoint can be used to
   // flood app_logs (cost + storage) and inject fake admin identities.
   const clientIp = getClientIp(event.headers)
   if (checkRateLimit(clientIp, { maxRequests: 30, windowMs: 60_000, prefix: 'client-logs' })) {
-    return {
-      statusCode: 429,
-      headers,
-      body: JSON.stringify({ error: 'Too many requests' }),
-    }
+    return errorResponse({ code: 'rate_limited', headers })
   }
 
   // Resolve identity from a verified bearer token if present. user_id /
@@ -80,20 +72,20 @@ export const handler: Handler = async (event) => {
 
     // Validate input
     if (!Array.isArray(logs) || logs.length === 0) {
-      return {
-        statusCode: 400,
+      return errorResponse({
+        code: 'invalid_input',
         headers,
-        body: JSON.stringify({ error: 'No logs provided' }),
-      }
+        message: 'No logs provided.',
+      })
     }
 
     // Limit batch size to prevent abuse
     if (logs.length > 100) {
-      return {
-        statusCode: 400,
+      return errorResponse({
+        code: 'invalid_input',
         headers,
-        body: JSON.stringify({ error: 'Too many logs in batch (max 100)' }),
-      }
+        message: 'Too many logs in batch (max 100).',
+      })
     }
 
     // Extract request context
@@ -137,11 +129,7 @@ export const handler: Handler = async (event) => {
     if (!response.ok) {
       const errorText = await response.text()
       console.error('Failed to insert client logs:', errorText)
-      return {
-        statusCode: 500,
-        headers,
-        body: JSON.stringify({ error: 'Failed to store logs' }),
-      }
+      return errorResponse({ code: 'server_error', headers })
     }
 
     return {
@@ -151,10 +139,6 @@ export const handler: Handler = async (event) => {
     }
   } catch (error) {
     console.error('Client logs error:', error)
-    return {
-      statusCode: 500,
-      headers,
-      body: JSON.stringify({ error: 'Internal server error' }),
-    }
+    return errorResponse({ code: 'server_error', headers })
   }
 }

--- a/cboa-site/netlify/functions/contact-form.ts
+++ b/cboa-site/netlify/functions/contact-form.ts
@@ -1,5 +1,5 @@
 import { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
-import { getCorsHeaders, supabase } from './_shared/handler'
+import { getCorsHeaders, supabase, errorResponse } from './_shared/handler'
 import { checkRateLimit, getClientIp } from './_shared/rateLimit'
 import { generateCBOAEmailTemplate } from '../../lib/emailTemplate'
 import { Logger } from '../../lib/logger'
@@ -142,15 +142,11 @@ export const handler: Handler = async (
   // Rate limit: 5 submissions per minute per IP
   const clientIp = getClientIp(event.headers)
   if (checkRateLimit(clientIp, { maxRequests: 5, windowMs: 60_000, prefix: 'contact' })) {
-    return { statusCode: 429, headers, body: JSON.stringify({ error: 'Too many requests. Please try again later.' }) }
+    return errorResponse({ code: 'rate_limited', headers })
   }
 
   if (event.httpMethod !== 'POST') {
-    return {
-      statusCode: 405,
-      headers,
-      body: JSON.stringify({ error: 'Method not allowed' })
-    }
+    return errorResponse({ code: 'method_not_allowed', headers })
   }
 
   try {
@@ -159,19 +155,21 @@ export const handler: Handler = async (
 
     // Validation
     if (!name || name.trim().length < 2) {
-      return {
-        statusCode: 400,
+      return errorResponse({
+        code: 'invalid_input',
         headers,
-        body: JSON.stringify({ error: 'Name is required' })
-      }
+        message: 'Please enter your name.',
+        fields: { name: 'Name is required' },
+      })
     }
 
     if (!email || !email.includes('@')) {
-      return {
-        statusCode: 400,
+      return errorResponse({
+        code: 'invalid_input',
         headers,
-        body: JSON.stringify({ error: 'Valid email is required' })
-      }
+        message: 'Please enter a valid email address.',
+        fields: { email: 'Valid email is required' },
+      })
     }
 
     // Enhanced email validation: MX record lookup + disposable domain blocking
@@ -180,48 +178,47 @@ export const handler: Handler = async (
       logger.info('email', 'contact_form_email_rejected', `Email rejected: ${emailValidation.reason}`, {
         metadata: { email, reason: emailValidation.reason, suggestion: emailValidation.suggestion }
       })
-      return {
-        statusCode: 400,
+      return errorResponse({
+        code: 'email_unavailable',
         headers,
-        body: JSON.stringify({
-          error: emailValidation.reason,
-          suggestion: emailValidation.suggestion,
-        })
-      }
+        message: emailValidation.suggestion
+          ? `That email address looks invalid. Did you mean ${emailValidation.suggestion}?`
+          : 'That email address looks invalid. Please double-check and try again.',
+        fields: { email: emailValidation.reason || 'Invalid email address' },
+        extra: emailValidation.suggestion ? { suggestion: emailValidation.suggestion } : undefined,
+      })
     }
 
     if (!category || !categoryEmailMap[category]) {
-      return {
-        statusCode: 400,
+      return errorResponse({
+        code: 'invalid_input',
         headers,
-        body: JSON.stringify({ error: 'Valid category is required' })
-      }
+        message: 'Please choose a category for your message.',
+        fields: { category: 'Please select a category' },
+      })
     }
 
     if (!subject || subject.trim().length < 5) {
-      return {
-        statusCode: 400,
+      return errorResponse({
+        code: 'invalid_input',
         headers,
-        body: JSON.stringify({ error: 'Subject is required' })
-      }
+        message: 'Please add a short subject (at least 5 characters).',
+        fields: { subject: 'Subject must be at least 5 characters' },
+      })
     }
 
     // If the client flagged this as a complaint, require email verification
     if (body.complaintDetected) {
       if (!body.verificationToken || !body.verificationCode) {
-        return {
-          statusCode: 400,
-          headers,
-          body: JSON.stringify({ error: 'Email verification is required for this type of message.' })
-        }
+        return errorResponse({ code: 'verification_required', headers })
       }
       const verification = verifyEmailToken(body.verificationToken, email, body.verificationCode)
       if (!verification.valid) {
-        return {
-          statusCode: 400,
+        return errorResponse({
+          code: 'verification_failed',
           headers,
-          body: JSON.stringify({ error: verification.reason })
-        }
+          message: verification.reason || 'That verification code didn’t match. Please check the email and try again.',
+        })
       }
       logger.info('email', 'contact_form_verified', 'Complaint submission with verified email', {
         metadata: { email }
@@ -229,22 +226,23 @@ export const handler: Handler = async (
     }
 
     if (!message || message.trim().length < 20) {
-      return {
-        statusCode: 400,
+      return errorResponse({
+        code: 'invalid_input',
         headers,
-        body: JSON.stringify({ error: 'Message must be at least 20 characters' })
-      }
+        message: 'Please add a bit more detail (at least 20 characters).',
+        fields: { message: 'Message must be at least 20 characters' },
+      })
     }
 
     // Validate attachment URLs
     if (body.attachmentUrls && body.attachmentUrls.length > 0) {
       const MAX_ATTACHMENTS = 5
       if (body.attachmentUrls.length > MAX_ATTACHMENTS) {
-        return {
-          statusCode: 400,
+        return errorResponse({
+          code: 'invalid_input',
           headers,
-          body: JSON.stringify({ error: `Maximum ${MAX_ATTACHMENTS} attachment links allowed` })
-        }
+          message: `Please limit attachments to ${MAX_ATTACHMENTS} links.`,
+        })
       }
 
       const allowedHosts = [
@@ -261,28 +259,28 @@ export const handler: Handler = async (
         try {
           parsed = new URL(url)
         } catch {
-          return {
-            statusCode: 400,
+          return errorResponse({
+            code: 'invalid_input',
             headers,
-            body: JSON.stringify({ error: `Invalid attachment URL: ${url}` })
-          }
+            message: 'One of your attachment links isn’t a valid URL. Please check and try again.',
+          })
         }
 
         if (parsed.protocol !== 'https:') {
-          return {
-            statusCode: 400,
+          return errorResponse({
+            code: 'invalid_input',
             headers,
-            body: JSON.stringify({ error: 'Attachment links must use HTTPS' })
-          }
+            message: 'Attachment links must start with https://.',
+          })
         }
 
         const host = parsed.hostname.toLowerCase()
         if (!allowedHosts.some(allowed => host === allowed || host.endsWith('.' + allowed))) {
-          return {
-            statusCode: 400,
+          return errorResponse({
+            code: 'invalid_input',
             headers,
-            body: JSON.stringify({ error: `Attachment links must be from a supported service (YouTube, Vimeo, Google Drive, Dropbox, Imgur, or OneDrive)` })
-          }
+            message: 'Attachments must be hosted on YouTube, Vimeo, Google Drive, Dropbox, Imgur, or OneDrive.',
+          })
         }
       }
 
@@ -313,11 +311,11 @@ export const handler: Handler = async (
               logger.info('email', 'contact_form_unsafe_url', 'Attachment URL flagged by Safe Browsing', {
                 metadata: { matches: sbData.matches.map((m: { threat?: { url?: string }; threatType?: string }) => ({ url: m.threat?.url, type: m.threatType })) }
               })
-              return {
-                statusCode: 400,
+              return errorResponse({
+                code: 'invalid_input',
                 headers,
-                body: JSON.stringify({ error: 'One or more attachment links were flagged as unsafe. Please check your links and try again.' })
-              }
+                message: 'One or more of your links was flagged as unsafe. Please check your attachments and try again.',
+              })
             }
           }
         } catch (sbError) {
@@ -332,11 +330,7 @@ export const handler: Handler = async (
         !process.env.MICROSOFT_CLIENT_ID ||
         !process.env.MICROSOFT_CLIENT_SECRET) {
       logger.error('email', 'contact_form_config_error', 'Microsoft Graph credentials not configured')
-      return {
-        statusCode: 500,
-        headers,
-        body: JSON.stringify({ error: 'Email service not configured' })
-      }
+      return errorResponse({ code: 'service_unavailable', headers })
     }
 
     const recipientEmail = categoryEmailMap[category]
@@ -532,15 +526,12 @@ export const handler: Handler = async (
     }
 
   } catch (error: unknown) {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
     logger.error('email', 'contact_form_error', 'Error processing contact form', error instanceof Error ? error : new Error(String(error)))
 
-    return {
-      statusCode: 500,
+    return errorResponse({
+      code: 'server_error',
       headers,
-      body: JSON.stringify({
-        error: 'Failed to send message. Please try again later.'
-      })
-    }
+      message: 'We couldn’t send your message right now. Please try again in a few minutes — if it keeps failing, email us at secretary@cboa.ca.',
+    })
   }
 }

--- a/cboa-site/netlify/functions/contact-submissions.ts
+++ b/cboa-site/netlify/functions/contact-submissions.ts
@@ -1,4 +1,4 @@
-import { createHandler, supabase } from './_shared/handler'
+import { createHandler, supabase, errorResponse } from './_shared/handler'
 
 export const handler = createHandler({
   name: 'contact-submissions',
@@ -62,7 +62,7 @@ export const handler = createHandler({
     const { id, status, notes } = body
 
     if (!id) {
-      return { statusCode: 400, body: JSON.stringify({ error: 'Submission ID is required' }) }
+      return errorResponse({ code: 'invalid_input', message: 'A submission must be selected.' })
     }
 
     const updates: Record<string, string> = {}

--- a/cboa-site/netlify/functions/evaluations.ts
+++ b/cboa-site/netlify/functions/evaluations.ts
@@ -1,4 +1,4 @@
-import { createHandler, supabase, type UserRole } from './_shared/handler'
+import { createHandler, supabase, type UserRole, errorResponse } from './_shared/handler'
 
 // Fine-grained role checks for evaluations
 function canViewAllEvaluations(role: UserRole): boolean {
@@ -45,7 +45,10 @@ export const handler = createHandler({
               .single()
 
             if (!memberData || data.member_id !== memberData.id) {
-              return { statusCode: 403, body: JSON.stringify({ error: 'Forbidden - You can only view your own evaluations' }) }
+              return errorResponse({
+            code: 'forbidden',
+            message: 'Forbidden - You can only view your own evaluations.'.replace('..', '.'),
+          })
             }
           }
 
@@ -61,7 +64,10 @@ export const handler = createHandler({
               .single()
 
             if (!memberData || member_id !== memberData.id) {
-              return { statusCode: 403, body: JSON.stringify({ error: 'Forbidden - You can only view your own evaluations' }) }
+              return errorResponse({
+            code: 'forbidden',
+            message: 'Forbidden - You can only view your own evaluations.'.replace('..', '.'),
+          })
             }
           }
 
@@ -77,7 +83,10 @@ export const handler = createHandler({
 
         if (evaluator_id) {
           if (!canViewAllEvaluations(userRole)) {
-            return { statusCode: 403, body: JSON.stringify({ error: 'Forbidden - Insufficient permissions' }) }
+            return errorResponse({
+            code: 'forbidden',
+            message: 'Forbidden - Insufficient permissions.'.replace('..', '.'),
+          })
           }
 
           const { data, error } = await supabase
@@ -91,7 +100,10 @@ export const handler = createHandler({
         }
 
         if (!canViewAllEvaluations(userRole)) {
-          return { statusCode: 403, body: JSON.stringify({ error: 'Forbidden - You can only view your own evaluations' }) }
+          return errorResponse({
+            code: 'forbidden',
+            message: 'Forbidden - You can only view your own evaluations.'.replace('..', '.'),
+          })
         }
 
         const { data, error } = await supabase
@@ -105,7 +117,10 @@ export const handler = createHandler({
 
       case 'POST': {
         if (!canCreateEvaluations(userRole)) {
-          return { statusCode: 403, body: JSON.stringify({ error: 'Forbidden - You do not have permission to create evaluations' }) }
+          return errorResponse({
+            code: 'forbidden',
+            message: 'Forbidden - You do not have permission to create evaluations.'.replace('..', '.'),
+          })
         }
 
         const body = JSON.parse(event.body || '{}')
@@ -114,7 +129,10 @@ export const handler = createHandler({
         })
 
         if (!body.member_id || !body.file_url || !body.file_name) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'member_id, file_url, and file_name are required' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A member, file URL, and file name are all required.',
+          })
         }
 
         const { data, error } = await supabase
@@ -147,14 +165,20 @@ export const handler = createHandler({
 
       case 'PUT': {
         if (!canModifyEvaluations(userRole)) {
-          return { statusCode: 403, body: JSON.stringify({ error: 'Forbidden - Only administrators and executives can edit evaluations' }) }
+          return errorResponse({
+            code: 'forbidden',
+            message: 'Forbidden - Only administrators and executives can edit evaluations.'.replace('..', '.'),
+          })
         }
 
         const body = JSON.parse(event.body || '{}')
         const { id, ...updateData } = body
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for update' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for update.',
+          })
         }
 
         logger.info('crud', 'update_evaluation', `Updating evaluation ${id} by ${userEmail} (${userRole})`, {
@@ -182,13 +206,19 @@ export const handler = createHandler({
 
       case 'DELETE': {
         if (!canModifyEvaluations(userRole)) {
-          return { statusCode: 403, body: JSON.stringify({ error: 'Forbidden - Only administrators and executives can delete evaluations' }) }
+          return errorResponse({
+            code: 'forbidden',
+            message: 'Forbidden - Only administrators and executives can delete evaluations.'.replace('..', '.'),
+          })
         }
 
         const { id } = event.queryStringParameters || {}
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for deletion' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for deletion.',
+          })
         }
 
         logger.info('crud', 'delete_evaluation', `Deleting evaluation ${id} by ${userEmail} (${userRole})`, { metadata: { id, actor_role: userRole } })
@@ -210,7 +240,7 @@ export const handler = createHandler({
       }
 
       default:
-        return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) }
+        return errorResponse({ code: 'method_not_allowed' })
     }
   }
 })

--- a/cboa-site/netlify/functions/executive-team.ts
+++ b/cboa-site/netlify/functions/executive-team.ts
@@ -1,4 +1,4 @@
-import { createHandler, supabase } from './_shared/handler'
+import { createHandler, supabase, errorResponse } from './_shared/handler'
 
 export const handler = createHandler({
   name: 'executive-team',
@@ -31,10 +31,15 @@ export const handler = createHandler({
         })
 
         if (!body.name || !body.position || !body.email) {
-          return {
-            statusCode: 400,
-            body: JSON.stringify({ error: 'Missing required fields: name, position, and email are required' })
-          }
+          const fields: Record<string, string> = {}
+          if (!body.name) fields.name = 'Name is required'
+          if (!body.position) fields.position = 'Position is required'
+          if (!body.email) fields.email = 'Email is required'
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'Name, position, and email are all required.',
+            fields,
+          })
         }
 
         const { data, error } = await supabase
@@ -68,7 +73,10 @@ export const handler = createHandler({
         const { id, ...updates } = body
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for updates' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for update.',
+          })
         }
 
         logger.info('crud', 'update_executive', `Updating executive member ${id}`, {
@@ -98,7 +106,10 @@ export const handler = createHandler({
         const id = event.queryStringParameters?.id
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for deletion' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for deletion.',
+          })
         }
 
         logger.info('crud', 'delete_executive', `Deleting executive member ${id}`, { metadata: { id } })
@@ -120,7 +131,7 @@ export const handler = createHandler({
       }
 
       default:
-        return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) }
+        return errorResponse({ code: 'method_not_allowed' })
     }
   }
 })

--- a/cboa-site/netlify/functions/identity-signup.ts
+++ b/cboa-site/netlify/functions/identity-signup.ts
@@ -9,10 +9,11 @@
  */
 
 import { Handler } from '@netlify/functions'
+import { errorResponse } from './_shared/handler'
 
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== 'POST') {
-    return { statusCode: 405, body: 'Method Not Allowed' }
+    return errorResponse({ code: 'method_not_allowed' })
   }
 
   try {
@@ -20,7 +21,10 @@ export const handler: Handler = async (event) => {
     const { user } = data
 
     if (!user?.email) {
-      return { statusCode: 400, body: JSON.stringify({ error: 'Invalid user data' }) }
+      return errorResponse({
+        code: 'invalid_input',
+        message: 'Signup request was missing user details.',
+      })
     }
 
     // Assign "official" role to all new signups

--- a/cboa-site/netlify/functions/list-resource-files.ts
+++ b/cboa-site/netlify/functions/list-resource-files.ts
@@ -1,5 +1,5 @@
 import { Handler } from '@netlify/functions'
-import { getCorsHeaders } from './_shared/handler'
+import { getCorsHeaders, errorResponse } from './_shared/handler'
 import * as fs from 'fs'
 import * as path from 'path'
 
@@ -13,11 +13,7 @@ export const handler: Handler = async (event) => {
   }
 
   if (event.httpMethod !== 'GET') {
-    return {
-      statusCode: 405,
-      headers,
-      body: JSON.stringify({ error: 'Method not allowed' })
-    }
+    return errorResponse({ code: 'method_not_allowed', headers })
   }
 
   try {
@@ -64,10 +60,6 @@ export const handler: Handler = async (event) => {
     }
   } catch (error) {
     console.error('Error listing files:', error)
-    return {
-      statusCode: 500,
-      headers,
-      body: JSON.stringify({ error: 'Failed to list files' })
-    }
+    return errorResponse({ code: 'server_error', headers })
   }
 }

--- a/cboa-site/netlify/functions/member-activities.ts
+++ b/cboa-site/netlify/functions/member-activities.ts
@@ -1,4 +1,4 @@
-import { createHandler, supabase } from './_shared/handler'
+import { createHandler, supabase, errorResponse } from './_shared/handler'
 
 export const handler = createHandler({
   name: 'member-activities',
@@ -55,7 +55,10 @@ export const handler = createHandler({
         const { id, ...updates } = body
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for updates' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for update.',
+          })
         }
 
         logger.info('crud', 'update_member_activity', `Updating member activity ${id}`, {
@@ -85,7 +88,10 @@ export const handler = createHandler({
         const id = event.queryStringParameters?.id
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for deletion' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for deletion.',
+          })
         }
 
         logger.info('crud', 'delete_member_activity', `Deleting member activity ${id}`, { metadata: { id } })
@@ -98,7 +104,10 @@ export const handler = createHandler({
 
         if (findError || !existing) {
           logger.warn('crud', 'delete_member_activity_not_found', `Member activity ${id} not found`, { metadata: { id } })
-          return { statusCode: 404, body: JSON.stringify({ error: 'Activity not found' }) }
+          return errorResponse({
+            code: 'not_found',
+            message: 'Activity not found.'.replace('..', '.'),
+          })
         }
 
         const { error } = await supabase
@@ -118,7 +127,7 @@ export const handler = createHandler({
       }
 
       default:
-        return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) }
+        return errorResponse({ code: 'method_not_allowed' })
     }
   }
 })

--- a/cboa-site/netlify/functions/members.ts
+++ b/cboa-site/netlify/functions/members.ts
@@ -1,4 +1,4 @@
-import { createHandler, findAuthUserByEmail } from './_shared/handler'
+import { createHandler, findAuthUserByEmail, errorResponse } from './_shared/handler'
 import {
   EMAIL_ANNOUNCEMENTS,
   ORG_NAME,
@@ -122,9 +122,9 @@ function generateInviteEmailHtml(inviteUrl: string, name?: string): string {
   `.trim()
 }
 
-const FORBIDDEN = (msg = 'Forbidden') => ({
-  statusCode: 403,
-  body: JSON.stringify({ error: msg })
+const FORBIDDEN = (msg?: string) => errorResponse({
+  code: 'forbidden',
+  message: msg,
 })
 
 export const handler = createHandler({
@@ -235,7 +235,11 @@ export const handler = createHandler({
         const { email, name, role, skipInvite, ...memberData } = body
 
         if (!email) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'Email is required' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'Email is required.',
+            fields: { email: 'Email is required' },
+          })
         }
 
         // Non-admins can only create their own member row, and may not assign a role
@@ -266,10 +270,12 @@ export const handler = createHandler({
           logger.warn('crud', 'create_member_exists', `Member already exists with email: ${email}`, {
             metadata: { email }
           })
-          return {
+          return errorResponse({
+            code: 'invalid_input',
             statusCode: 409,
-            body: JSON.stringify({ error: 'Member with this email already exists' })
-          }
+            message: 'A member with that email address already exists.',
+            fields: { email: 'Already in use' },
+          })
         }
 
         // Check if auth user already exists
@@ -301,10 +307,10 @@ export const handler = createHandler({
 
             if (linkError) {
               logger.error('crud', 'create_member_invite_failed', `Failed to create auth user: ${linkError.message}`, new Error(linkError.message))
-              return {
-                statusCode: 400,
-                body: JSON.stringify({ error: 'Failed to create auth user' })
-              }
+              return errorResponse({
+                code: 'server_error',
+                message: 'We couldn’t set up an account for that member. Please try again.',
+              })
             }
 
             authUserId = linkData.user?.id || null
@@ -364,7 +370,10 @@ export const handler = createHandler({
         const { id, ...updates } = body
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for updates' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A member must be selected.',
+          })
         }
 
         const { data: existing } = await supabase
@@ -374,7 +383,7 @@ export const handler = createHandler({
           .single()
 
         if (!existing) {
-          return { statusCode: 404, body: JSON.stringify({ error: 'Member not found' }) }
+          return errorResponse({ code: 'not_found', message: 'That member couldn’t be found.' })
         }
 
         // Non-admins must own the row, either by user_id link or (for the
@@ -441,7 +450,10 @@ export const handler = createHandler({
         const id = event.queryStringParameters?.id
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for deletion' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A member must be selected for deletion.',
+          })
         }
 
         logger.info('crud', 'delete_member_start', `Deleting member ${id}`, {
@@ -505,6 +517,6 @@ export const handler = createHandler({
       }
     }
 
-    return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) }
+    return errorResponse({ code: 'method_not_allowed' })
   }
 })

--- a/cboa-site/netlify/functions/migrate-netlify-users.ts
+++ b/cboa-site/netlify/functions/migrate-netlify-users.ts
@@ -1,5 +1,5 @@
 import { Handler } from '@netlify/functions'
-import { supabase as supabaseAdmin, getCorsHeaders, listAllAuthUsers } from './_shared/handler'
+import { supabase as supabaseAdmin, getCorsHeaders, listAllAuthUsers, errorResponse } from './_shared/handler'
 import {
   EMAIL_NO_REPLY,
   ORG_NAME,
@@ -130,7 +130,7 @@ export const handler: Handler = async (event) => {
   }
 
   if (event.httpMethod !== 'POST') {
-    return { statusCode: 405, headers, body: JSON.stringify({ error: 'Method not allowed' }) }
+    return errorResponse({ code: 'method_not_allowed', headers })
   }
 
   // Verify authorization - accept either migration secret or Supabase admin token
@@ -148,16 +148,16 @@ export const handler: Handler = async (event) => {
       const { data: { user: callerUser }, error: authError } = await supabaseAdmin.auth.getUser(token)
 
       if (authError || !callerUser) {
-        return { statusCode: 401, headers, body: JSON.stringify({ error: 'Invalid token' }) }
+        return errorResponse({ code: 'unauthorized', headers })
       }
 
       const callerRole = callerUser.app_metadata?.role || callerUser.user_metadata?.role
       if (callerRole?.toLowerCase() !== 'admin') {
-        return { statusCode: 403, headers, body: JSON.stringify({ error: 'Admin access required' }) }
+        return errorResponse({ code: 'forbidden', headers })
       }
     }
   } else {
-    return { statusCode: 401, headers, body: JSON.stringify({ error: 'Unauthorized' }) }
+    return errorResponse({ code: 'unauthorized', headers })
   }
 
   const body = JSON.parse(event.body || '{}')
@@ -192,8 +192,9 @@ export const handler: Handler = async (event) => {
           }))
         })
       }
-    } catch (err: any) {
-      return { statusCode: 500, headers, body: JSON.stringify({ error: err.message }) }
+    } catch (err) {
+      console.error('[MigrateNetlifyUsers] Backup error:', err)
+      return errorResponse({ code: 'server_error', headers })
     }
   }
 
@@ -201,11 +202,11 @@ export const handler: Handler = async (event) => {
   const membersToMigrate: MemberToMigrate[] = members.length > 0 ? members : await getMemberList()
 
   if (membersToMigrate.length === 0) {
-    return {
-      statusCode: 400,
+    return errorResponse({
+      code: 'invalid_input',
       headers,
-      body: JSON.stringify({ error: 'No members to migrate. Provide members array in request body.' })
-    }
+      message: 'No members to migrate. Provide a members array in the request body.',
+    })
   }
 
   try {
@@ -317,13 +318,9 @@ export const handler: Handler = async (event) => {
         results
       })
     }
-  } catch (error: any) {
+  } catch (error) {
     console.error('Migration error:', error)
-    return {
-      statusCode: 500,
-      headers,
-      body: JSON.stringify({ error: error.message })
-    }
+    return errorResponse({ code: 'server_error', headers })
   }
 }
 

--- a/cboa-site/netlify/functions/newsletters.ts
+++ b/cboa-site/netlify/functions/newsletters.ts
@@ -1,4 +1,4 @@
-import { createHandler, supabase } from './_shared/handler'
+import { createHandler, supabase, errorResponse } from './_shared/handler'
 
 export const handler = createHandler({
   name: 'newsletters',
@@ -46,7 +46,10 @@ export const handler = createHandler({
         const { id, ...updates } = body
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for updates' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for update.',
+          })
         }
 
         logger.info('crud', 'update_newsletter', `Updating newsletter ${id}`, {
@@ -76,7 +79,10 @@ export const handler = createHandler({
         const id = event.queryStringParameters?.id
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for deletion' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for deletion.',
+          })
         }
 
         logger.info('crud', 'delete_newsletter', `Deleting newsletter ${id}`, { metadata: { id } })
@@ -98,7 +104,7 @@ export const handler = createHandler({
       }
 
       default:
-        return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) }
+        return errorResponse({ code: 'method_not_allowed' })
     }
   }
 })

--- a/cboa-site/netlify/functions/officials.ts
+++ b/cboa-site/netlify/functions/officials.ts
@@ -1,4 +1,4 @@
-import { createHandler, supabase } from './_shared/handler'
+import { createHandler, supabase, errorResponse } from './_shared/handler'
 
 export const handler = createHandler({
   name: 'officials',
@@ -31,7 +31,11 @@ export const handler = createHandler({
         })
 
         if (!body.name) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'Missing required field: name' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'Name is required.',
+            fields: { name: 'Name is required' },
+          })
         }
 
         const { data, error } = await supabase
@@ -57,7 +61,10 @@ export const handler = createHandler({
         const { id, ...updates } = body
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for updates' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for update.',
+          })
         }
 
         logger.info('crud', 'update_official', `Updating official ${id}`, {
@@ -87,7 +94,10 @@ export const handler = createHandler({
         const id = event.queryStringParameters?.id
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for deletion' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for deletion.',
+          })
         }
 
         logger.info('crud', 'delete_official', `Deleting official ${id}`, { metadata: { id } })
@@ -109,7 +119,7 @@ export const handler = createHandler({
       }
 
       default:
-        return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) }
+        return errorResponse({ code: 'method_not_allowed' })
     }
   }
 })

--- a/cboa-site/netlify/functions/osa-submissions.ts
+++ b/cboa-site/netlify/functions/osa-submissions.ts
@@ -1,4 +1,4 @@
-import { createHandler, supabase } from './_shared/handler'
+import { createHandler, supabase, errorResponse } from './_shared/handler'
 import { osaExcelSync } from '../../lib/excel-sync'
 
 export const handler = createHandler({
@@ -61,7 +61,7 @@ export const handler = createHandler({
     const { id, status, notes } = body
 
     if (!id) {
-      return { statusCode: 400, body: JSON.stringify({ error: 'Submission ID required' }) }
+      return errorResponse({ code: 'invalid_input', message: 'A submission must be selected.' })
     }
 
     const updateData: Record<string, any> = {}
@@ -69,7 +69,7 @@ export const handler = createHandler({
     if (notes !== undefined) updateData.notes = notes
 
     if (Object.keys(updateData).length === 0) {
-      return { statusCode: 400, body: JSON.stringify({ error: 'No update data provided' }) }
+      return errorResponse({ code: 'invalid_input', message: 'No update data was provided.' })
     }
 
     const { data, error } = await supabase

--- a/cboa-site/netlify/functions/osa-webhook.ts
+++ b/cboa-site/netlify/functions/osa-webhook.ts
@@ -2,7 +2,7 @@ import { Handler, HandlerEvent } from '@netlify/functions'
 import { generateCBOAEmailTemplate } from '../../lib/emailTemplate'
 import { Logger } from '../../lib/logger'
 import { osaExcelSync, OSASubmissionData } from '../../lib/excel-sync'
-import { supabase } from './_shared/handler'
+import { supabase, errorResponse } from './_shared/handler'
 import { checkRateLimit, getClientIp } from './_shared/rateLimit'
 import * as fs from 'fs'
 import * as path from 'path'
@@ -739,20 +739,14 @@ export const handler: Handler = async (event: HandlerEvent) => {
 
   // Only allow POST
   if (event.httpMethod !== 'POST') {
-    return {
-      statusCode: 405,
-      body: JSON.stringify({ error: 'Method not allowed' })
-    }
+    return errorResponse({ code: 'method_not_allowed' })
   }
 
   // Rate limit per IP. Each call sends up to 4 Microsoft Graph emails
   // and writes DB rows; 10/min is generous for legit users + retries.
   const clientIp = getClientIp(event.headers)
   if (checkRateLimit(clientIp, { maxRequests: 10, windowMs: 60_000, prefix: 'osa-webhook' })) {
-    return {
-      statusCode: 429,
-      body: JSON.stringify({ error: 'Too many requests. Please try again later.' })
-    }
+    return errorResponse({ code: 'rate_limited' })
   }
 
   try {
@@ -767,13 +761,10 @@ export const handler: Handler = async (event: HandlerEvent) => {
       // Legacy single-event format - convert to multi-event
       formData = convertLegacyToMultiEvent(rawData as LegacyFormData)
     } else {
-      return {
-        statusCode: 400,
-        body: JSON.stringify({
-          error: 'Invalid form data format',
-          message: 'Expected either events array or eventType field'
-        })
-      }
+      return errorResponse({
+        code: 'invalid_input',
+        message: 'Your submission was missing event details. Please refresh the page and try again.',
+      })
     }
 
     const eventCount = formData.events.length
@@ -783,18 +774,15 @@ export const handler: Handler = async (event: HandlerEvent) => {
 
     // Validate required fields
     if (!formData.organizationName || !formData.eventContactEmail || !formData.events.length) {
-      return {
-        statusCode: 400,
-        body: JSON.stringify({
-          error: 'Missing required fields',
-          required: ['organizationName', 'eventContactEmail', 'events'],
-          received: {
-            organizationName: !!formData.organizationName,
-            eventContactEmail: !!formData.eventContactEmail,
-            eventsCount: formData.events?.length || 0
-          }
-        })
-      }
+      const fields: Record<string, string> = {}
+      if (!formData.organizationName) fields.organizationName = 'Organization name is required'
+      if (!formData.eventContactEmail) fields.eventContactEmail = 'Event contact email is required'
+      if (!formData.events.length) fields.events = 'At least one event is required'
+      return errorResponse({
+        code: 'invalid_input',
+        message: 'Some required information is missing. Please review the form and try again.',
+        fields,
+      })
     }
 
     // Compute a deterministic submission_group_id from the form data so
@@ -853,10 +841,7 @@ export const handler: Handler = async (event: HandlerEvent) => {
         !process.env.MICROSOFT_CLIENT_ID ||
         !process.env.MICROSOFT_CLIENT_SECRET) {
       logger.error('osa', 'config_error', 'Microsoft Graph credentials not configured')
-      return {
-        statusCode: 500,
-        body: JSON.stringify({ error: 'Email service not configured' })
-      }
+      return errorResponse({ code: 'service_unavailable' })
     }
 
     // Get access token
@@ -1156,11 +1141,9 @@ export const handler: Handler = async (event: HandlerEvent) => {
 
   } catch (error: any) {
     logger.error('osa', 'webhook_error', 'Error processing OSA webhook', error)
-    return {
-      statusCode: 500,
-      body: JSON.stringify({
-        error: error.message || 'Failed to process form submission'
-      })
-    }
+    return errorResponse({
+      code: 'server_error',
+      message: 'We couldn’t finish processing your request. Please try again, or contact us at scheduler@cboa.ca if it keeps failing.',
+    })
   }
 }

--- a/cboa-site/netlify/functions/public-news.ts
+++ b/cboa-site/netlify/functions/public-news.ts
@@ -1,4 +1,4 @@
-import { createHandler, supabase } from './_shared/handler'
+import { createHandler, supabase, errorResponse } from './_shared/handler'
 
 export const handler = createHandler({
   name: 'public-news',
@@ -18,7 +18,10 @@ export const handler = createHandler({
           if (error) throw error
 
           if (!data) {
-            return { statusCode: 404, body: JSON.stringify({ error: 'News article not found' }) }
+            return errorResponse({
+            code: 'not_found',
+            message: 'News article not found.'.replace('..', '.'),
+          })
           }
 
           return { statusCode: 200, body: JSON.stringify(data) }
@@ -42,10 +45,18 @@ export const handler = createHandler({
         })
 
         if (!body.title || !body.slug || !body.published_date || !body.author || !body.excerpt || !body.body) {
-          return {
-            statusCode: 400,
-            body: JSON.stringify({ error: 'Missing required fields: title, slug, published_date, author, excerpt, body' })
-          }
+          const fields: Record<string, string> = {}
+          if (!body.title) fields.title = 'Title is required'
+          if (!body.slug) fields.slug = 'Slug is required'
+          if (!body.published_date) fields.published_date = 'Published date is required'
+          if (!body.author) fields.author = 'Author is required'
+          if (!body.excerpt) fields.excerpt = 'Excerpt is required'
+          if (!body.body) fields.body = 'Body is required'
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'Title, slug, published date, author, excerpt, and body are all required.',
+            fields,
+          })
         }
 
         const { data, error } = await supabase
@@ -71,7 +82,10 @@ export const handler = createHandler({
         const { id, ...updates } = body
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for updates' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for update.',
+          })
         }
 
         logger.info('crud', 'update_public_news', `Updating news article ${id}`, {
@@ -101,7 +115,10 @@ export const handler = createHandler({
         const id = event.queryStringParameters?.id
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for deletion' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for deletion.',
+          })
         }
 
         logger.info('crud', 'delete_public_news', `Deleting news article ${id}`, { metadata: { id } })
@@ -123,7 +140,7 @@ export const handler = createHandler({
       }
 
       default:
-        return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) }
+        return errorResponse({ code: 'method_not_allowed' })
     }
   }
 })

--- a/cboa-site/netlify/functions/public-pages.ts
+++ b/cboa-site/netlify/functions/public-pages.ts
@@ -1,4 +1,4 @@
-import { createHandler, supabase } from './_shared/handler'
+import { createHandler, supabase, errorResponse } from './_shared/handler'
 
 export const handler = createHandler({
   name: 'public-pages',
@@ -19,7 +19,10 @@ export const handler = createHandler({
           if (error) throw error
 
           if (!data) {
-            return { statusCode: 404, body: JSON.stringify({ error: 'Page not found' }) }
+            return errorResponse({
+            code: 'not_found',
+            message: 'Page not found.'.replace('..', '.'),
+          })
           }
 
           return { statusCode: 200, body: JSON.stringify(data) }
@@ -41,10 +44,15 @@ export const handler = createHandler({
         })
 
         if (!body.page_name || !body.title || !body.content) {
-          return {
-            statusCode: 400,
-            body: JSON.stringify({ error: 'Missing required fields: page_name, title, content' })
-          }
+          const fields: Record<string, string> = {}
+          if (!body.page_name) fields.page_name = 'Page name is required'
+          if (!body.title) fields.title = 'Title is required'
+          if (!body.content) fields.content = 'Content is required'
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'Page name, title, and content are all required.',
+            fields,
+          })
         }
 
         const { data, error } = await supabase
@@ -70,7 +78,10 @@ export const handler = createHandler({
         const { id, ...updates } = body
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for updates' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for update.',
+          })
         }
 
         logger.info('crud', 'update_public_page', `Updating page ${id}`, {
@@ -100,7 +111,10 @@ export const handler = createHandler({
         const id = event.queryStringParameters?.id
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for deletion' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for deletion.',
+          })
         }
 
         logger.info('crud', 'delete_public_page', `Deleting page ${id}`, { metadata: { id } })
@@ -122,7 +136,7 @@ export const handler = createHandler({
       }
 
       default:
-        return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) }
+        return errorResponse({ code: 'method_not_allowed' })
     }
   }
 })

--- a/cboa-site/netlify/functions/public-resources.ts
+++ b/cboa-site/netlify/functions/public-resources.ts
@@ -1,4 +1,4 @@
-import { createHandler, supabase } from './_shared/handler'
+import { createHandler, supabase, errorResponse } from './_shared/handler'
 
 export const handler = createHandler({
   name: 'public-resources',
@@ -18,7 +18,10 @@ export const handler = createHandler({
           if (error) throw error
 
           if (!data) {
-            return { statusCode: 404, body: JSON.stringify({ error: 'Resource not found' }) }
+            return errorResponse({
+            code: 'not_found',
+            message: 'Resource not found.'.replace('..', '.'),
+          })
           }
 
           return { statusCode: 200, body: JSON.stringify(data) }
@@ -47,10 +50,17 @@ export const handler = createHandler({
         })
 
         if (!body.title || !body.slug || !body.category || !body.description || !body.last_updated) {
-          return {
-            statusCode: 400,
-            body: JSON.stringify({ error: 'Missing required fields: title, slug, category, description, last_updated' })
-          }
+          const fields: Record<string, string> = {}
+          if (!body.title) fields.title = 'Title is required'
+          if (!body.slug) fields.slug = 'Slug is required'
+          if (!body.category) fields.category = 'Category is required'
+          if (!body.description) fields.description = 'Description is required'
+          if (!body.last_updated) fields.last_updated = 'Last updated is required'
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'Title, slug, category, description, and last updated are all required.',
+            fields,
+          })
         }
 
         const { data, error } = await supabase
@@ -76,7 +86,10 @@ export const handler = createHandler({
         const { id, ...updates } = body
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for updates' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for update.',
+          })
         }
 
         logger.info('crud', 'update_public_resource', `Updating resource ${id}`, {
@@ -106,7 +119,10 @@ export const handler = createHandler({
         const id = event.queryStringParameters?.id
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for deletion' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for deletion.',
+          })
         }
 
         logger.info('crud', 'delete_public_resource', `Deleting resource ${id}`, { metadata: { id } })
@@ -128,7 +144,7 @@ export const handler = createHandler({
       }
 
       default:
-        return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) }
+        return errorResponse({ code: 'method_not_allowed' })
     }
   }
 })

--- a/cboa-site/netlify/functions/public-training.ts
+++ b/cboa-site/netlify/functions/public-training.ts
@@ -1,4 +1,4 @@
-import { createHandler, supabase } from './_shared/handler'
+import { createHandler, supabase, errorResponse } from './_shared/handler'
 
 export const handler = createHandler({
   name: 'public-training',
@@ -18,7 +18,10 @@ export const handler = createHandler({
           if (error) throw error
 
           if (!data) {
-            return { statusCode: 404, body: JSON.stringify({ error: 'Training event not found' }) }
+            return errorResponse({
+            code: 'not_found',
+            message: 'Training event not found.'.replace('..', '.'),
+          })
           }
 
           return { statusCode: 200, body: JSON.stringify(data) }
@@ -42,10 +45,10 @@ export const handler = createHandler({
         })
 
         if (!body.title || !body.slug || !body.event_date || !body.start_time || !body.end_time || !body.location || !body.event_type || !body.description) {
-          return {
-            statusCode: 400,
-            body: JSON.stringify({ error: 'Missing required fields: title, slug, event_date, start_time, end_time, location, event_type, description' })
-          }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'Title, slug, event date, start time, end time, location, event type, and description are all required.',
+          })
         }
 
         const { data, error } = await supabase
@@ -71,7 +74,10 @@ export const handler = createHandler({
         const { id, ...updates } = body
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for updates' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for update.',
+          })
         }
 
         logger.info('crud', 'update_training_event', `Updating training event ${id}`, {
@@ -101,7 +107,10 @@ export const handler = createHandler({
         const id = event.queryStringParameters?.id
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for deletion' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for deletion.',
+          })
         }
 
         logger.info('crud', 'delete_training_event', `Deleting training event ${id}`, { metadata: { id } })
@@ -123,7 +132,7 @@ export const handler = createHandler({
       }
 
       default:
-        return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) }
+        return errorResponse({ code: 'method_not_allowed' })
     }
   }
 })

--- a/cboa-site/netlify/functions/resend-invites.ts
+++ b/cboa-site/netlify/functions/resend-invites.ts
@@ -1,5 +1,6 @@
 import { Handler } from '@netlify/functions';
 import { SITE_URL as CONFIG_SITE_URL } from '../../lib/siteConfig';
+import { errorResponse } from './_shared/handler';
 
 /**
  * Netlify Function to resend invites to pending Identity users
@@ -117,18 +118,12 @@ export const handler: Handler = async (event, context) => {
   const { identity, user } = context.clientContext || {};
 
   if (!identity || !user) {
-    return {
-      statusCode: 401,
-      body: JSON.stringify({ error: 'Unauthorized - must be logged in' })
-    };
+    return errorResponse({ code: 'unauthorized' });
   }
 
   // Check admin role
   if (!isAdmin(user)) {
-    return {
-      statusCode: 403,
-      body: JSON.stringify({ error: 'Forbidden - admin role required' })
-    };
+    return errorResponse({ code: 'forbidden' });
   }
 
   const isDryRun = event.queryStringParameters?.['dry-run'] === 'true' || event.httpMethod === 'GET';
@@ -139,10 +134,10 @@ export const handler: Handler = async (event, context) => {
   const adminToken = event.headers['x-admin-token'] || (identity as any).token;
 
   if (!adminToken) {
-    return {
-      statusCode: 400,
-      body: JSON.stringify({ error: 'Admin token required in x-admin-token header' })
-    };
+    return errorResponse({
+      code: 'invalid_input',
+      message: 'Admin token required in x-admin-token header.',
+    });
   }
 
   try {
@@ -204,9 +199,7 @@ export const handler: Handler = async (event, context) => {
     };
 
   } catch (error) {
-    return {
-      statusCode: 500,
-      body: JSON.stringify({ error: 'Internal server error' })
-    };
+    console.error('[ResendInvites] Error:', error);
+    return errorResponse({ code: 'server_error' });
   }
 };

--- a/cboa-site/netlify/functions/resources.ts
+++ b/cboa-site/netlify/functions/resources.ts
@@ -1,4 +1,4 @@
-import { createHandler, supabase } from './_shared/handler'
+import { createHandler, supabase, errorResponse } from './_shared/handler'
 
 export const handler = createHandler({
   name: 'resources',
@@ -49,7 +49,10 @@ export const handler = createHandler({
         const { id, ...updateData } = body
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for update' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for update.',
+          })
         }
 
         logger.info('crud', 'update_resource', `Updating resource ${id}`, {
@@ -78,7 +81,10 @@ export const handler = createHandler({
         const { id } = event.queryStringParameters || {}
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for deletion' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for deletion.',
+          })
         }
 
         logger.info('crud', 'delete_resource', `Deleting resource ${id}`, { metadata: { id } })
@@ -100,7 +106,7 @@ export const handler = createHandler({
       }
 
       default:
-        return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) }
+        return errorResponse({ code: 'method_not_allowed' })
     }
   }
 })

--- a/cboa-site/netlify/functions/rule-modifications.ts
+++ b/cboa-site/netlify/functions/rule-modifications.ts
@@ -1,4 +1,4 @@
-import { createHandler, supabase } from './_shared/handler'
+import { createHandler, supabase, errorResponse } from './_shared/handler'
 
 export const handler = createHandler({
   name: 'rule-modifications',
@@ -47,7 +47,10 @@ export const handler = createHandler({
         const { id, ...updates } = body
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for updates' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for update.',
+          })
         }
 
         logger.info('crud', 'update_rule_modification', `Updating rule modification ${id}`, {
@@ -77,7 +80,10 @@ export const handler = createHandler({
         const id = event.queryStringParameters?.id
 
         if (!id) {
-          return { statusCode: 400, body: JSON.stringify({ error: 'ID is required for deletion' }) }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for deletion.',
+          })
         }
 
         logger.info('crud', 'delete_rule_modification', `Deleting rule modification ${id}`, { metadata: { id } })
@@ -99,7 +105,7 @@ export const handler = createHandler({
       }
 
       default:
-        return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) }
+        return errorResponse({ code: 'method_not_allowed' })
     }
   }
 })

--- a/cboa-site/netlify/functions/scheduled-log-cleanup.ts
+++ b/cboa-site/netlify/functions/scheduled-log-cleanup.ts
@@ -16,7 +16,7 @@ export const handler = schedule('0 3 * * 0', async () => {
 
     if (error) {
       console.error('Log cleanup failed:', error)
-      return { statusCode: 500, body: JSON.stringify({ error: error.message }) }
+      return { statusCode: 500, body: JSON.stringify({ error: 'server_error', message: 'Log cleanup failed.' }) }
     }
 
     console.log('Log cleanup completed:', data)
@@ -29,6 +29,6 @@ export const handler = schedule('0 3 * * 0', async () => {
     }
   } catch (err) {
     console.error('Log cleanup error:', err)
-    return { statusCode: 500, body: JSON.stringify({ error: 'Cleanup failed' }) }
+    return { statusCode: 500, body: JSON.stringify({ error: 'server_error', message: 'Log cleanup failed.' }) }
   }
 })

--- a/cboa-site/netlify/functions/scheduler-updates.ts
+++ b/cboa-site/netlify/functions/scheduler-updates.ts
@@ -1,4 +1,4 @@
-import { createHandler, supabase } from './_shared/handler'
+import { createHandler, supabase, errorResponse } from './_shared/handler'
 
 export const handler = createHandler({
   name: 'scheduler-updates',
@@ -55,10 +55,10 @@ export const handler = createHandler({
         const { id, ...updateData } = body
 
         if (!id) {
-          return {
-            statusCode: 400,
-            body: JSON.stringify({ error: 'ID is required for update' })
-          }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for update.',
+          })
         }
 
         logger.info('crud', 'update_scheduler_update', `Updating scheduler update ${id}`, {
@@ -90,10 +90,10 @@ export const handler = createHandler({
         const { id } = event.queryStringParameters || {}
 
         if (!id) {
-          return {
-            statusCode: 400,
-            body: JSON.stringify({ error: 'ID is required for deletion' })
-          }
+          return errorResponse({
+            code: 'invalid_input',
+            message: 'A record must be selected for deletion.',
+          })
         }
 
         logger.info('crud', 'delete_scheduler_update', `Deleting scheduler update ${id}`, {
@@ -120,10 +120,7 @@ export const handler = createHandler({
       }
 
       default:
-        return {
-          statusCode: 405,
-          body: JSON.stringify({ error: 'Method not allowed' })
-        }
+        return errorResponse({ code: 'method_not_allowed' })
     }
   }
 })

--- a/cboa-site/netlify/functions/send-email.ts
+++ b/cboa-site/netlify/functions/send-email.ts
@@ -1,4 +1,4 @@
-import { createHandler, supabase } from './_shared/handler'
+import { createHandler, supabase, errorResponse } from './_shared/handler'
 import { generateCBOAEmailTemplate } from '../../lib/emailTemplate'
 import { recordBulkEmail } from '../../lib/emailHistory'
 import { EMAIL_ANNOUNCEMENTS } from '../../lib/siteConfig'
@@ -182,18 +182,29 @@ export const handler = createHandler({
 
     // Validation
     if (!subject?.trim()) {
-      return { statusCode: 400, body: JSON.stringify({ error: 'Subject is required' }) }
+      return errorResponse({
+        code: 'invalid_input',
+        message: 'Please add a subject for this email.',
+        fields: { subject: 'Subject is required' },
+      })
     }
     if (!htmlContent?.trim()) {
-      return { statusCode: 400, body: JSON.stringify({ error: 'Email content is required' }) }
+      return errorResponse({
+        code: 'invalid_input',
+        message: 'Please add some content to the email.',
+        fields: { htmlContent: 'Email content is required' },
+      })
     }
     if ((!recipientGroups || recipientGroups.length === 0) && (!customEmails || customEmails.length === 0)) {
-      return { statusCode: 400, body: JSON.stringify({ error: 'At least one recipient is required' }) }
+      return errorResponse({
+        code: 'invalid_input',
+        message: 'Please choose at least one recipient or recipient group.',
+      })
     }
 
     if (!process.env.MICROSOFT_TENANT_ID || !process.env.MICROSOFT_CLIENT_ID || !process.env.MICROSOFT_CLIENT_SECRET) {
       logger.error('email', 'send_email_config_error', 'Microsoft Graph credentials not configured')
-      return { statusCode: 500, body: JSON.stringify({ error: 'Email service not configured' }) }
+      return errorResponse({ code: 'service_unavailable' })
     }
 
     try {
@@ -204,7 +215,10 @@ export const handler = createHandler({
       )
 
       if (recipientEmails.length === 0) {
-        return { statusCode: 400, body: JSON.stringify({ error: 'No valid recipients found' }) }
+        return errorResponse({
+          code: 'invalid_input',
+          message: 'None of the selected groups had any active members. Please pick a different set of recipients.',
+        })
       }
 
       logger.info('email', 'send_email_recipients', `Found ${recipientEmails.length} recipients`, {

--- a/cboa-site/netlify/functions/send-welcome-emails.ts
+++ b/cboa-site/netlify/functions/send-welcome-emails.ts
@@ -1,5 +1,5 @@
 import { Handler } from '@netlify/functions'
-import { supabase as supabaseAdmin, getCorsHeaders } from './_shared/handler'
+import { supabase as supabaseAdmin, getCorsHeaders, errorResponse } from './_shared/handler'
 import { Logger } from '../../lib/logger'
 import {
   EMAIL_ANNOUNCEMENTS,
@@ -163,14 +163,14 @@ const handler: Handler = async (event) => {
   }
 
   if (event.httpMethod !== 'POST') {
-    return { statusCode: 405, headers, body: JSON.stringify({ error: 'Method not allowed' }) }
+    return errorResponse({ code: 'method_not_allowed', headers })
   }
 
   // Verify migration secret
   const authHeader = event.headers.authorization
   if (!authHeader || authHeader !== `Bearer ${migrationSecret}`) {
     logger.warn('auth', 'unauthorized_request', 'Unauthorized welcome email request')
-    return { statusCode: 401, headers, body: JSON.stringify({ error: 'Unauthorized' }) }
+    return errorResponse({ code: 'unauthorized', headers })
   }
 
   try {
@@ -182,7 +182,11 @@ const handler: Handler = async (event) => {
     })
 
     if (!users || !Array.isArray(users)) {
-      return { statusCode: 400, headers, body: JSON.stringify({ error: 'users array is required' }) }
+      return errorResponse({
+        code: 'invalid_input',
+        headers,
+        message: 'A users array is required.',
+      })
     }
 
     // Fetch all Supabase users to verify they exist
@@ -193,7 +197,8 @@ const handler: Handler = async (event) => {
     while (true) {
       const { data: { users: pageUsers }, error } = await supabaseAdmin.auth.admin.listUsers({ page, perPage })
       if (error) {
-        return { statusCode: 500, headers, body: JSON.stringify({ error: `Failed to fetch users: ${error.message}` }) }
+        logger.error('email', 'welcome_emails_list_failed', 'Failed to list auth users', new Error(error.message))
+        return errorResponse({ code: 'server_error', headers })
       }
       if (!pageUsers || pageUsers.length === 0) break
       allSupabaseUsers = allSupabaseUsers.concat(pageUsers)
@@ -210,8 +215,9 @@ const handler: Handler = async (event) => {
     if (!dryRun) {
       try {
         accessToken = await getAccessToken()
-      } catch (err: any) {
-        return { statusCode: 500, headers, body: JSON.stringify({ error: `Graph API auth failed: ${err.message}` }) }
+      } catch (err) {
+        logger.error('email', 'welcome_emails_graph_auth_failed', 'Graph API auth failed', err instanceof Error ? err : new Error(String(err)))
+        return errorResponse({ code: 'service_unavailable', headers })
       }
     }
 
@@ -291,9 +297,9 @@ const handler: Handler = async (event) => {
       })
     }
 
-  } catch (error: any) {
+  } catch (error) {
     logger.error('email', 'welcome_emails_error', 'Error sending welcome emails', error instanceof Error ? error : new Error(String(error)))
-    return { statusCode: 500, headers, body: JSON.stringify({ error: error.message }) }
+    return errorResponse({ code: 'server_error', headers })
   }
 }
 

--- a/cboa-site/netlify/functions/supabase-auth-admin.ts
+++ b/cboa-site/netlify/functions/supabase-auth-admin.ts
@@ -1,5 +1,5 @@
 import { Handler } from '@netlify/functions'
-import { supabase as supabaseAdmin, getCorsHeaders, listAllAuthUsers, findAuthUserByEmail } from './_shared/handler'
+import { supabase as supabaseAdmin, getCorsHeaders, listAllAuthUsers, findAuthUserByEmail, errorResponse } from './_shared/handler'
 import { checkRateLimit, getClientIp } from './_shared/rateLimit'
 import { randomBytes } from 'crypto'
 import { Logger } from '../../lib/logger'
@@ -288,11 +288,12 @@ export const handler: Handler = async (event) => {
         const { email } = body
 
         if (!email) {
-          return {
-            statusCode: 400,
+          return errorResponse({
+            code: 'invalid_input',
             headers,
-            body: JSON.stringify({ error: 'Email is required' })
-          }
+            message: 'Please enter your email address.',
+            fields: { email: 'Email is required' },
+          })
         }
 
         // Rate limit: 3 requests per minute per IP. Without this the
@@ -300,11 +301,7 @@ export const handler: Handler = async (event) => {
         // Microsoft Graph quota.
         const clientIp = getClientIp(event.headers)
         if (checkRateLimit(clientIp, { maxRequests: 3, windowMs: 60_000, prefix: 'request-invite' })) {
-          return {
-            statusCode: 429,
-            headers,
-            body: JSON.stringify({ error: 'Too many requests. Please try again in a minute.' })
-          }
+          return errorResponse({ code: 'rate_limited', headers })
         }
 
         const normalizedEmail = email.toLowerCase().trim()
@@ -366,11 +363,7 @@ export const handler: Handler = async (event) => {
         // Check Microsoft Graph credentials
         if (!process.env.MICROSOFT_TENANT_ID || !process.env.MICROSOFT_CLIENT_ID || !process.env.MICROSOFT_CLIENT_SECRET) {
           logger.error('auth', 'request_invite_config_error', 'Microsoft Graph credentials not configured')
-          return {
-            statusCode: 500,
-            headers,
-            body: JSON.stringify({ error: 'Email service not configured' })
-          }
+          return errorResponse({ code: 'service_unavailable', headers })
         }
 
         // Create a proxy invite token (never expires)
@@ -412,11 +405,7 @@ export const handler: Handler = async (event) => {
         // Continue to normal auth flow
       } else {
         logger.error('auth', 'request_invite_error', 'Error processing invite request', err)
-        return {
-          statusCode: 500,
-          headers,
-          body: JSON.stringify({ error: 'An error occurred' })
-        }
+        return errorResponse({ code: 'server_error', headers })
       }
     }
   }
@@ -425,11 +414,7 @@ export const handler: Handler = async (event) => {
   const authHeader = event.headers.authorization || event.headers.Authorization
   if (!authHeader?.startsWith('Bearer ')) {
     logger.warn('auth', 'unauthorized_request', 'Request without token')
-    return {
-      statusCode: 401,
-      headers,
-      body: JSON.stringify({ error: 'Unauthorized - No token provided' })
-    }
+    return errorResponse({ code: 'unauthorized', headers })
   }
 
   const token = authHeader.split(' ')[1]
@@ -440,11 +425,7 @@ export const handler: Handler = async (event) => {
 
     if (authError || !callerUser) {
       logger.warn('auth', 'invalid_token', 'Invalid or expired token')
-      return {
-        statusCode: 401,
-        headers,
-        body: JSON.stringify({ error: 'Unauthorized - Invalid token' })
-      }
+      return errorResponse({ code: 'unauthorized', headers })
     }
 
     // Check if caller has admin role
@@ -454,11 +435,7 @@ export const handler: Handler = async (event) => {
         userEmail: callerUser.email,
         metadata: { role: callerRole }
       })
-      return {
-        statusCode: 403,
-        headers,
-        body: JSON.stringify({ error: 'Forbidden - Admin access required' })
-      }
+      return errorResponse({ code: 'forbidden', headers })
     }
 
     // Set caller context for subsequent logs
@@ -524,11 +501,11 @@ export const handler: Handler = async (event) => {
           }
         }
 
-        return {
-          statusCode: 400,
+        return errorResponse({
+          code: 'invalid_input',
           headers,
-          body: JSON.stringify({ error: 'Missing action or email parameter' })
-        }
+          message: 'Missing action or email parameter.',
+        })
       }
 
       case 'POST': {
@@ -543,11 +520,8 @@ export const handler: Handler = async (event) => {
 
           // Check Microsoft Graph credentials
           if (!process.env.MICROSOFT_TENANT_ID || !process.env.MICROSOFT_CLIENT_ID || !process.env.MICROSOFT_CLIENT_SECRET) {
-            return {
-              statusCode: 500,
-              headers,
-              body: JSON.stringify({ error: 'Microsoft Graph credentials not configured' })
-            }
+            logger.error('auth', 'resend_pending_config_error', 'Microsoft Graph credentials not configured')
+            return errorResponse({ code: 'service_unavailable', headers })
           }
 
           // Get all members who haven't signed in yet
@@ -559,11 +533,7 @@ export const handler: Handler = async (event) => {
 
           if (queryError) {
             logger.error('auth', 'resend_pending_query_failed', 'Failed to query pending members', new Error(queryError.message))
-            return {
-              statusCode: 500,
-              headers,
-              body: JSON.stringify({ error: 'Failed to query members' })
-            }
+            return errorResponse({ code: 'server_error', headers })
           }
 
           // Get all auth users to check who hasn't signed in
@@ -659,20 +629,18 @@ export const handler: Handler = async (event) => {
         }
 
         if (!email) {
-          return {
-            statusCode: 400,
+          return errorResponse({
+            code: 'invalid_input',
             headers,
-            body: JSON.stringify({ error: 'Email is required' })
-          }
+            message: 'Email is required.',
+            fields: { email: 'Email is required' },
+          })
         }
 
         // Check Microsoft Graph credentials
         if (!process.env.MICROSOFT_TENANT_ID || !process.env.MICROSOFT_CLIENT_ID || !process.env.MICROSOFT_CLIENT_SECRET) {
-          return {
-            statusCode: 500,
-            headers,
-            body: JSON.stringify({ error: 'Microsoft Graph credentials not configured' })
-          }
+          logger.error('auth', 'invite_config_error', 'Microsoft Graph credentials not configured')
+          return errorResponse({ code: 'service_unavailable', headers })
         }
 
         // Resend invite - delete existing user and re-invite with proxy token
@@ -764,11 +732,12 @@ export const handler: Handler = async (event) => {
             userEmail: callerUser.email,
             metadata: { targetEmail: email }
           })
-          return {
-            statusCode: 400,
+          return errorResponse({
+            code: 'invalid_input',
             headers,
-            body: JSON.stringify({ success: false, error: 'User already exists' })
-          }
+            message: 'A user with that email already exists.',
+            extra: { success: false },
+          })
         }
 
         // Create a proxy invite token (never expires)
@@ -840,11 +809,7 @@ export const handler: Handler = async (event) => {
           // Check Microsoft Graph credentials
           if (!process.env.MICROSOFT_TENANT_ID || !process.env.MICROSOFT_CLIENT_ID || !process.env.MICROSOFT_CLIENT_SECRET) {
             logger.error('auth', 'password_reset_config_error', 'Microsoft Graph credentials not configured')
-            return {
-              statusCode: 500,
-              headers,
-              body: JSON.stringify({ error: 'Microsoft Graph credentials not configured' })
-            }
+            return errorResponse({ code: 'service_unavailable', headers })
           }
 
           // Generate password reset link
@@ -858,11 +823,12 @@ export const handler: Handler = async (event) => {
 
           if (linkError) {
             logger.error('auth', 'password_reset_failed', `Failed to generate reset link for ${email}`, new Error(linkError.message))
-            return {
-              statusCode: 400,
+            return errorResponse({
+              code: 'service_unavailable',
               headers,
-              body: JSON.stringify({ success: false, error: 'Failed to generate password reset link' })
-            }
+              message: 'We couldn’t send a password reset email right now. Please try again in a few minutes.',
+              extra: { success: false },
+            })
           }
 
           // Send email via Microsoft Graph
@@ -912,11 +878,11 @@ export const handler: Handler = async (event) => {
 
         // Update user metadata
         if (!userId) {
-          return {
-            statusCode: 400,
+          return errorResponse({
+            code: 'invalid_input',
             headers,
-            body: JSON.stringify({ error: 'userId is required' })
-          }
+            message: 'A user must be selected.',
+          })
         }
 
         logger.info('auth', 'update_user_start', `Updating user ${userId}`, {
@@ -938,11 +904,12 @@ export const handler: Handler = async (event) => {
 
         if (error) {
           logger.error('auth', 'update_user_failed', `Failed to update user ${userId}`, new Error(error.message))
-          return {
-            statusCode: 400,
+          return errorResponse({
+            code: 'server_error',
             headers,
-            body: JSON.stringify({ success: false, error: error.message })
-          }
+            message: 'We couldn’t update that user. Please try again.',
+            extra: { success: false },
+          })
         }
 
         // Audit log for role change
@@ -991,11 +958,11 @@ export const handler: Handler = async (event) => {
         const { email } = event.queryStringParameters || {}
 
         if (!email) {
-          return {
-            statusCode: 400,
+          return errorResponse({
+            code: 'invalid_input',
             headers,
-            body: JSON.stringify({ error: 'Email is required' })
-          }
+            message: 'Email is required.',
+          })
         }
 
         logger.info('auth', 'delete_user_start', `Deleting user ${email}`, {
@@ -1011,22 +978,24 @@ export const handler: Handler = async (event) => {
             userEmail: callerUser.email,
             metadata: { targetEmail: email }
           })
-          return {
-            statusCode: 404,
+          return errorResponse({
+            code: 'not_found',
             headers,
-            body: JSON.stringify({ success: false, error: 'User not found' })
-          }
+            message: 'No user found with that email.',
+            extra: { success: false },
+          })
         }
 
         const { error } = await supabaseAdmin.auth.admin.deleteUser(user.id)
 
         if (error) {
           logger.error('auth', 'delete_user_failed', `Failed to delete user ${email}`, new Error(error.message))
-          return {
-            statusCode: 400,
+          return errorResponse({
+            code: 'server_error',
             headers,
-            body: JSON.stringify({ success: false, error: error.message })
-          }
+            message: 'We couldn’t delete that user. Please try again.',
+            extra: { success: false },
+          })
         }
 
         // Audit log
@@ -1056,20 +1025,10 @@ export const handler: Handler = async (event) => {
       }
 
       default:
-        return {
-          statusCode: 405,
-          headers,
-          body: JSON.stringify({ error: 'Method not allowed' })
-        }
+        return errorResponse({ code: 'method_not_allowed', headers })
     }
   } catch (error) {
     logger.error('auth', 'api_error', 'Supabase Auth Admin API error', error instanceof Error ? error : new Error(String(error)))
-    return {
-      statusCode: 500,
-      headers,
-      body: JSON.stringify({
-        error: 'Internal server error'
-      })
-    }
+    return errorResponse({ code: 'server_error', headers })
   }
 }

--- a/cboa-site/netlify/functions/sync-members-auth.ts
+++ b/cboa-site/netlify/functions/sync-members-auth.ts
@@ -1,5 +1,5 @@
 import { Handler } from '@netlify/functions'
-import { supabase, getCorsHeaders } from './_shared/handler'
+import { supabase, getCorsHeaders, errorResponse } from './_shared/handler'
 import {
   EMAIL_ANNOUNCEMENTS,
   ORG_NAME,
@@ -110,25 +110,25 @@ export const handler: Handler = async (event) => {
   }
 
   if (event.httpMethod !== 'POST') {
-    return { statusCode: 405, headers, body: JSON.stringify({ error: 'Method not allowed' }) }
+    return errorResponse({ code: 'method_not_allowed', headers })
   }
 
   // Verify authorization - require admin JWT
   const authHeader = event.headers.authorization
   if (!authHeader?.startsWith('Bearer ')) {
-    return { statusCode: 401, headers, body: JSON.stringify({ error: 'Unauthorized' }) }
+    return errorResponse({ code: 'unauthorized', headers })
   }
 
   const token = authHeader.split(' ')[1]
   const { data: { user: callerUser }, error: authError } = await supabase.auth.getUser(token)
 
   if (authError || !callerUser) {
-    return { statusCode: 401, headers, body: JSON.stringify({ error: 'Invalid token' }) }
+    return errorResponse({ code: 'unauthorized', headers })
   }
 
   const callerRole = callerUser.app_metadata?.role || callerUser.user_metadata?.role
   if (callerRole !== 'admin' && callerRole !== 'Admin') {
-    return { statusCode: 403, headers, body: JSON.stringify({ error: 'Admin access required' }) }
+    return errorResponse({ code: 'forbidden', headers })
   }
 
   try {
@@ -302,12 +302,8 @@ export const handler: Handler = async (event) => {
       })
     }
 
-  } catch (error: any) {
+  } catch (error) {
     console.error('Sync error:', error)
-    return {
-      statusCode: 500,
-      headers,
-      body: JSON.stringify({ error: error.message })
-    }
+    return errorResponse({ code: 'server_error', headers })
   }
 }

--- a/cboa-site/netlify/functions/upload-file.ts
+++ b/cboa-site/netlify/functions/upload-file.ts
@@ -1,6 +1,6 @@
 import { Handler } from '@netlify/functions'
 import busboy from 'busboy'
-import { supabase, getUserRole } from './_shared/handler'
+import { supabase, getUserRole, errorResponse } from './_shared/handler'
 import { Logger } from '../../lib/logger'
 import { SITE_URL } from '../../lib/siteConfig'
 
@@ -29,20 +29,20 @@ export const handler: Handler = async (event): Promise<{ statusCode: number; hea
   }
 
   if (event.httpMethod !== 'POST') {
-    return { statusCode: 405, headers, body: JSON.stringify({ error: 'Method not allowed' }) }
+    return errorResponse({ code: 'method_not_allowed', headers })
   }
 
   // Verify authentication — any logged-in user can upload
   const authHeader = event.headers.authorization || event.headers.Authorization
   if (!authHeader?.startsWith('Bearer ')) {
-    return { statusCode: 401, headers, body: JSON.stringify({ error: 'Unauthorized' }) }
+    return errorResponse({ code: 'unauthorized', headers })
   }
 
   const token = authHeader.replace('Bearer ', '')
   const { data: { user: authUser }, error: authError } = await supabase.auth.getUser(token)
 
   if (authError || !authUser) {
-    return { statusCode: 401, headers, body: JSON.stringify({ error: 'Unauthorized' }) }
+    return errorResponse({ code: 'unauthorized', headers })
   }
 
   const userRole = getUserRole(authUser)
@@ -86,7 +86,12 @@ export const handler: Handler = async (event): Promise<{ statusCode: number; hea
           logger.warn('file', 'file_too_large', `File too large: ${originalFileName}`, {
             metadata: { filename: originalFileName, size: fileSize }
           })
-          resolve({ statusCode: 413, headers, body: JSON.stringify({ error: 'File too large (max 10MB)' }) })
+          resolve(errorResponse({
+            code: 'invalid_input',
+            statusCode: 413,
+            headers,
+            message: 'That file is too large — please upload a file under 10 MB.',
+          }))
         }
       })
 
@@ -104,7 +109,11 @@ export const handler: Handler = async (event): Promise<{ statusCode: number; hea
     bb.on('finish', async () => {
       if (rejected) return
       if (!fileBuffer.length) {
-        resolve({ statusCode: 400, headers, body: JSON.stringify({ error: 'No file received' }) })
+        resolve(errorResponse({
+          code: 'invalid_input',
+          headers,
+          message: 'No file was received. Please pick a file and try again.',
+        }))
         return
       }
 
@@ -125,7 +134,11 @@ export const handler: Handler = async (event): Promise<{ statusCode: number; hea
           logger.warn('file', 'upload_forbidden', `Non-privileged user tried to upload to ${bucket}`, {
             metadata: { userEmail, role: userRole, bucket, filename: originalFileName }
           })
-          resolve({ statusCode: 403, headers, body: JSON.stringify({ error: 'Forbidden: insufficient role for this bucket' }) })
+          resolve(errorResponse({
+            code: 'forbidden',
+            headers,
+            message: 'You don’t have permission to upload to this location.',
+          }))
           return
         }
 
@@ -159,7 +172,11 @@ export const handler: Handler = async (event): Promise<{ statusCode: number; hea
           logger.error('file', 'upload_failed', `Upload failed: ${originalFileName}`, new Error(error.message), {
             metadata: { filename: originalFileName, bucket }
           })
-          resolve({ statusCode: 500, headers, body: JSON.stringify({ error: 'Upload failed' }) })
+          resolve(errorResponse({
+            code: 'server_error',
+            headers,
+            message: 'We couldn’t save that file. Please try again in a moment.',
+          }))
           return
         }
 
@@ -195,13 +212,21 @@ export const handler: Handler = async (event): Promise<{ statusCode: number; hea
         logger.error('file', 'upload_error', 'Error uploading file', error instanceof Error ? error : new Error(String(error)), {
           metadata: { filename: originalFileName }
         })
-        resolve({ statusCode: 500, headers, body: JSON.stringify({ error: 'Failed to upload file' }) })
+        resolve(errorResponse({
+          code: 'server_error',
+          headers,
+          message: 'We couldn’t save that file. Please try again in a moment.',
+        }))
       }
     })
 
     bb.on('error', (error) => {
       logger.error('file', 'busboy_error', 'File parsing error', error instanceof Error ? error : new Error(String(error)))
-      resolve({ statusCode: 500, headers, body: JSON.stringify({ error: 'File upload failed' }) })
+      resolve(errorResponse({
+        code: 'server_error',
+        headers,
+        message: 'We couldn’t save that file. Please try again in a moment.',
+      }))
     })
 
     if (event.body) {
@@ -210,7 +235,11 @@ export const handler: Handler = async (event): Promise<{ statusCode: number; hea
         : Buffer.from(event.body)
       bb.end(buffer)
     } else {
-      resolve({ statusCode: 400, headers, body: JSON.stringify({ error: 'No body received' }) })
+      resolve(errorResponse({
+        code: 'invalid_input',
+        headers,
+        message: 'No file was received. Please pick a file and try again.',
+      }))
     }
   })
 }

--- a/cboa-site/netlify/functions/verify-email.ts
+++ b/cboa-site/netlify/functions/verify-email.ts
@@ -1,5 +1,5 @@
 import { Handler } from '@netlify/functions'
-import { getCorsHeaders } from './_shared/handler'
+import { getCorsHeaders, errorResponse } from './_shared/handler'
 import { checkRateLimit, getClientIp } from './_shared/rateLimit'
 import { createHmac } from 'crypto'
 import { generateCBOAEmailTemplate } from '../../lib/emailTemplate'
@@ -110,18 +110,23 @@ export const handler: Handler = async (event) => {
   // Rate limit: 5 verification requests per minute per IP
   const clientIp = getClientIp(event.headers)
   if (checkRateLimit(clientIp, { maxRequests: 5, windowMs: 60_000, prefix: 'verify-email' })) {
-    return { statusCode: 429, headers, body: JSON.stringify({ error: 'Too many requests. Please try again later.' }) }
+    return errorResponse({ code: 'rate_limited', headers })
   }
 
   if (event.httpMethod !== 'POST') {
-    return { statusCode: 405, headers, body: JSON.stringify({ error: 'Method not allowed' }) }
+    return errorResponse({ code: 'method_not_allowed', headers })
   }
 
   try {
     const { email, code: providedCode, token: providedToken } = JSON.parse(event.body || '{}')
 
     if (!email) {
-      return { statusCode: 400, headers, body: JSON.stringify({ error: 'Email is required' }) }
+      return errorResponse({
+        code: 'invalid_input',
+        headers,
+        message: 'Please enter your email address.',
+        fields: { email: 'Email is required' },
+      })
     }
 
     // Verification mode: caller has a token and a 6-digit code, wants
@@ -132,17 +137,26 @@ export const handler: Handler = async (event) => {
       if (result.valid) {
         return { statusCode: 200, headers, body: JSON.stringify({ success: true, valid: true }) }
       }
-      return { statusCode: 400, headers, body: JSON.stringify({ success: false, valid: false, error: result.reason || 'Invalid code' }) }
+      return errorResponse({
+        code: 'verification_failed',
+        headers,
+        message: result.reason || 'That code didn’t match. Please check the email and try again.',
+        extra: { success: false, valid: false },
+      })
     }
 
     // Validate the email first (MX check, disposable blocking)
     const emailValidation = await validateEmail(email)
     if (!emailValidation.valid) {
-      return {
-        statusCode: 400,
+      return errorResponse({
+        code: 'email_unavailable',
         headers,
-        body: JSON.stringify({ error: emailValidation.reason, suggestion: emailValidation.suggestion }),
-      }
+        message: emailValidation.suggestion
+          ? `That email address looks invalid. Did you mean ${emailValidation.suggestion}?`
+          : 'That email address looks invalid. Please double-check and try again.',
+        fields: { email: emailValidation.reason || 'Invalid email address' },
+        extra: emailValidation.suggestion ? { suggestion: emailValidation.suggestion } : undefined,
+      })
     }
 
     // Generate 6-digit code
@@ -204,10 +218,10 @@ export const handler: Handler = async (event) => {
     }
   } catch (error) {
     console.error('[VerifyEmail] Error:', error)
-    return {
-      statusCode: 500,
+    return errorResponse({
+      code: 'service_unavailable',
       headers,
-      body: JSON.stringify({ error: 'Failed to send verification email. Please try again.' }),
-    }
+      message: 'We couldn’t send a verification email right now. Please try again in a few minutes.',
+    })
   }
 }


### PR DESCRIPTION
## Summary
- Public-facing forms now show calm, plain-language errors instead of leaking strings like *"Email service not configured"*, *"Microsoft Graph credentials not configured"*, or *"Failed to fetch"*.
- New shared error-code vocabulary on the server (`netlify/functions/_shared/errorResponse.ts`) emits `{ error, message?, fields? }` with stable codes (`rate_limited`, `invalid_input`, `email_unavailable`, `verification_failed`, `service_unavailable`, `server_error`, …).
- New client helper `lib/userFacingError.ts` (`toFriendlyMessage`, `readFriendlyError`, `friendlyErrorFromThrown`) maps server codes / status codes to user-safe copy and falls back to a generic *"Something went wrong on our end — please try again, or contact us if the problem persists."*
- `OSARequestFormWizard` previously dropped submit errors to `console.error` only — submission failures now surface as a banner on the review step.
- Server still logs full context via `Logger.error(...)`; only the response body is sanitized.

## Before / after — sample messages

| Trigger | Before | After |
| --- | --- | --- |
| Hit contact-form rate limit | `Too many requests. Please try again later.` | `You're going a bit fast — please wait a minute and try again.` |
| MS Graph credentials missing on contact-form | `Email service not configured` | `We couldn't reach a service we depend on. Please try again in a few minutes.` |
| Generic 500 from any function-via-`createHandler` | `Internal server error` | `Something went wrong on our end — please try again, or contact us if the problem persists.` |
| OSA wizard fails on submit | (silent — only `console.error`) | Banner on review step + friendly helper message (e.g. *"We couldn't finish processing your request. Please try again, or contact us at scheduler@cboa.ca if it keeps failing."*) |
| Network failure (`Failed to fetch`) | `Failed to fetch` / `Failed to send message` | `We couldn't reach the server. Please check your internet connection and try again.` |
| Email typo on contact-form | `Did you mean foo@gmail.com?` (stand-alone) | Same hint + `email` field error + corrected value pre-filled |

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest` — 88 / 88 pass
- [ ] Manual: submit contact form with bad email; verify field error appears under email and banner uses friendly copy
- [ ] Manual: submit OSA wizard with no Graph creds locally; verify banner appears on step 5
- [ ] Manual: hit rate limit on `/.netlify/functions/contact-form`; verify friendly toast/banner copy
- [ ] Manual: open admin pages (logs, email-history, osa-submissions, contact-submissions) with a stale token; verify friendly "Please sign in" / "You don't have permission" copy instead of `Forbidden` / `Unauthorized`