### PR TITLE
feat(dashboard): scheduler updates widget under Upcoming Events

### DIFF
--- a/cboa-site/__tests__/unit/dashboard/SchedulerUpdatesWidget.test.tsx
+++ b/cboa-site/__tests__/unit/dashboard/SchedulerUpdatesWidget.test.tsx
@@ -1,0 +1,131 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import SchedulerUpdatesWidget from '@/components/dashboard/SchedulerUpdatesWidget'
+
+jest.mock('@/lib/api', () => ({
+  schedulerUpdatesAPI: {
+    getAll: jest.fn(),
+  },
+}))
+
+// HTMLViewer pulls in TinyMCE which isn't worth booting in jsdom — stub it
+// to a simple div that just exposes the raw HTML so tests can inspect it.
+jest.mock('@/components/TinyMCEEditor', () => ({
+  HTMLViewer: ({ content }: { content: string }) => (
+    <div data-testid="html-viewer" dangerouslySetInnerHTML={{ __html: content }} />
+  ),
+}))
+
+import { schedulerUpdatesAPI } from '@/lib/api'
+
+const mockApi = schedulerUpdatesAPI as unknown as { getAll: jest.Mock }
+
+const updates = [
+  {
+    id: 'u1',
+    title: 'New CBE games posted',
+    content: '<p>Check Arbiter for the new assignments.</p>',
+    author: 'Scheduler',
+    date: '2026-04-01T12:00:00.000Z',
+  },
+  {
+    id: 'u2',
+    title: 'Tournament weekend coverage',
+    content: '<p>We need more refs for May 10–11.</p>',
+    author: 'Jerome',
+    date: '2026-03-25T12:00:00.000Z',
+  },
+]
+
+describe('SchedulerUpdatesWidget', () => {
+  beforeEach(() => {
+    mockApi.getAll.mockReset()
+  })
+
+  it('shows a loading skeleton, then renders updates sorted newest-first', async () => {
+    let resolve: (v: unknown) => void = () => {}
+    mockApi.getAll.mockReturnValueOnce(new Promise((r) => (resolve = r)))
+
+    render(<SchedulerUpdatesWidget />)
+    // Header is visible during loading
+    expect(screen.getByText('Scheduler Updates')).toBeInTheDocument()
+
+    await act(async () => {
+      resolve([updates[1], updates[0]]) // unsorted on purpose
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('New CBE games posted')).toBeInTheDocument()
+    })
+
+    // Newest first: 'u1' (Apr 01) before 'u2' (Mar 25).
+    const titles = screen.getAllByRole('heading', { level: 3 }).map((h) => h.textContent)
+    expect(titles).toEqual(['New CBE games posted', 'Tournament weekend coverage'])
+  })
+
+  it('auto-expands the most recent update on load', async () => {
+    mockApi.getAll.mockResolvedValueOnce(updates)
+    render(<SchedulerUpdatesWidget />)
+
+    await waitFor(() => {
+      expect(screen.getByText('New CBE games posted')).toBeInTheDocument()
+    })
+
+    // Most recent's HTML content is rendered (not just the title).
+    const viewers = screen.getAllByTestId('html-viewer')
+    expect(viewers).toHaveLength(1)
+    expect(viewers[0].innerHTML).toContain('Check Arbiter')
+  })
+
+  it('toggles expansion when a row is clicked', async () => {
+    mockApi.getAll.mockResolvedValueOnce(updates)
+    render(<SchedulerUpdatesWidget />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Tournament weekend coverage')).toBeInTheDocument()
+    })
+
+    const secondRow = screen.getByRole('button', { name: /Tournament weekend coverage/ })
+    fireEvent.click(secondRow)
+
+    await waitFor(() => {
+      const viewers = screen.getAllByTestId('html-viewer')
+      // First update collapses, second expands.
+      expect(viewers).toHaveLength(1)
+      expect(viewers[0].innerHTML).toContain('We need more refs')
+    })
+  })
+
+  it('renders an empty state when the API returns no updates', async () => {
+    mockApi.getAll.mockResolvedValueOnce([])
+    render(<SchedulerUpdatesWidget />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No scheduler updates yet')).toBeInTheDocument()
+    })
+  })
+
+  it('renders the empty state when the API throws', async () => {
+    const consoleErr = jest.spyOn(console, 'error').mockImplementation(() => {})
+    mockApi.getAll.mockRejectedValueOnce(new Error('network down'))
+
+    render(<SchedulerUpdatesWidget />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No scheduler updates yet')).toBeInTheDocument()
+    })
+    consoleErr.mockRestore()
+  })
+
+  it('links the "All" affordance to the scheduler-updates page', async () => {
+    mockApi.getAll.mockResolvedValueOnce(updates)
+    render(<SchedulerUpdatesWidget />)
+
+    await waitFor(() => {
+      expect(screen.getByText('New CBE games posted')).toBeInTheDocument()
+    })
+
+    const allLink = screen.getByRole('link', { name: /All/ })
+    expect(allLink).toHaveAttribute('href', '/portal/scheduler-updates')
+  })
+})

--- a/cboa-site/app/portal/page.tsx
+++ b/cboa-site/app/portal/page.tsx
@@ -23,6 +23,7 @@ import {
 import UpcomingEventsWidget from '@/components/dashboard/UpcomingEventsWidget';
 import LatestAnnouncementWidget from '@/components/dashboard/LatestAnnouncementWidget';
 import LatestNewsletterWidget from '@/components/dashboard/LatestNewsletterWidget';
+import SchedulerUpdatesWidget from '@/components/dashboard/SchedulerUpdatesWidget';
 
 export default function PortalDashboard() {
   const { user } = useRole();
@@ -144,8 +145,11 @@ export default function PortalDashboard() {
         {/* Latest Announcement */}
         <LatestAnnouncementWidget />
 
-        {/* Upcoming Events */}
-        <UpcomingEventsWidget />
+        {/* Upcoming Events stacked with Scheduler Updates beneath */}
+        <div className="space-y-4">
+          <UpcomingEventsWidget />
+          <SchedulerUpdatesWidget />
+        </div>
       </div>
 
       {/* Latest Newsletter - Full Width */}

--- a/cboa-site/components/dashboard/SchedulerUpdatesWidget.tsx
+++ b/cboa-site/components/dashboard/SchedulerUpdatesWidget.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import Link from 'next/link'
+import { IconClipboardList, IconChevronRight, IconChevronDown } from '@tabler/icons-react'
+import { schedulerUpdatesAPI } from '@/lib/api'
+import { HTMLViewer } from '@/components/TinyMCEEditor'
+
+interface SchedulerUpdate {
+  id: string
+  title: string
+  content: string
+  author: string
+  date: string
+}
+
+const MAX_UPDATES = 10
+
+export default function SchedulerUpdatesWidget() {
+  const [updates, setUpdates] = useState<SchedulerUpdate[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+
+  useEffect(() => {
+    loadUpdates()
+  }, [])
+
+  const loadUpdates = async () => {
+    try {
+      const data = await schedulerUpdatesAPI.getAll()
+      if (Array.isArray(data) && data.length > 0) {
+        const sorted = [...data].sort(
+          (a: SchedulerUpdate, b: SchedulerUpdate) =>
+            new Date(b.date).getTime() - new Date(a.date).getTime()
+        )
+        const sliced = sorted.slice(0, MAX_UPDATES)
+        setUpdates(sliced)
+        // Auto-expand the most recent update so the latest content is visible.
+        setExpandedId(sliced[0].id)
+      }
+    } catch (error) {
+      console.error('Failed to load scheduler updates:', error)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const Header = (
+    <div className="flex items-center justify-between mb-2">
+      <h2 className="font-heading text-sm font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+        <IconClipboardList className="h-4 w-4 text-orange-500" />
+        Scheduler Updates
+      </h2>
+      <Link
+        href="/portal/scheduler-updates"
+        className="text-xs text-orange-600 dark:text-portal-accent hover:text-orange-700 font-medium flex items-center gap-0.5"
+      >
+        All
+        <IconChevronRight className="h-3 w-3" />
+      </Link>
+    </div>
+  )
+
+  if (isLoading) {
+    return (
+      <div className="bg-white dark:bg-portal-surface rounded-lg border border-gray-200 dark:border-portal-border p-3 sm:p-4">
+        {Header}
+        <div className="animate-pulse space-y-2">
+          <div className="h-8 bg-gray-200 dark:bg-portal-hover rounded"></div>
+          <div className="h-8 bg-gray-200 dark:bg-portal-hover rounded"></div>
+          <div className="h-8 bg-gray-200 dark:bg-portal-hover rounded"></div>
+        </div>
+      </div>
+    )
+  }
+
+  if (updates.length === 0) {
+    return (
+      <div className="bg-white dark:bg-portal-surface rounded-lg border border-gray-200 dark:border-portal-border p-3 sm:p-4">
+        {Header}
+        <div className="text-center py-6 text-gray-500 dark:text-gray-400">
+          <p className="text-xs">No scheduler updates yet</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-white dark:bg-portal-surface rounded-lg border border-gray-200 dark:border-portal-border p-3 sm:p-4">
+      {Header}
+
+      <div className="divide-y divide-gray-100 dark:divide-portal-border -mx-3 sm:-mx-4">
+        {updates.map((update) => {
+          const isExpanded = expandedId === update.id
+          return (
+            <div key={update.id}>
+              <button
+                onClick={() => setExpandedId(isExpanded ? null : update.id)}
+                className="w-full text-left flex items-start gap-2 px-3 sm:px-4 py-2 hover:bg-gray-50 dark:hover:bg-portal-hover/50 transition-colors"
+                aria-expanded={isExpanded}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-1.5 mb-0.5">
+                    <span className="text-[10px] text-gray-400 dark:text-gray-500">
+                      {new Date(update.date).toLocaleDateString('en-US', {
+                        month: 'short',
+                        day: 'numeric',
+                      })}
+                    </span>
+                    <span className="text-[10px] text-gray-400 dark:text-gray-500">
+                      &middot; {update.author}
+                    </span>
+                  </div>
+                  <h3
+                    className={`font-medium text-sm text-gray-900 dark:text-white ${
+                      isExpanded ? '' : 'truncate'
+                    }`}
+                  >
+                    {update.title}
+                  </h3>
+                </div>
+                <IconChevronDown
+                  className={`h-4 w-4 text-gray-400 flex-shrink-0 mt-1 transition-transform duration-200 ${
+                    isExpanded ? 'rotate-180' : ''
+                  }`}
+                />
+              </button>
+
+              {isExpanded && (
+                <div className="px-3 sm:px-4 pb-3 pt-0">
+                  <div className="text-sm text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-portal-hover/30 rounded-md p-2.5">
+                    <HTMLViewer content={update.content} className="tinymce-content-compact" />
+                    <div className="mt-2 pt-2 border-t border-gray-200 dark:border-portal-border text-[10px] text-gray-400 dark:text-gray-500">
+                      Posted by {update.author}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Adds a new `SchedulerUpdatesWidget` to the portal dashboard, stacked directly underneath `UpcomingEventsWidget` in the right column of the existing 2-column grid.

**Layout change** in `app/portal/page.tsx`:

Before:
```
[Announcements] [Upcoming Events]
[Newsletter (full width)]
```

After:
```
[Announcements] [Upcoming Events]
                [Scheduler Updates]   <-- new
[Newsletter (full width)]
```

The widget mirrors the existing `LatestAnnouncementWidget` pattern:
- Accordion list of recent updates (newest first, capped at 10)
- Auto-expands the most recent so the latest content is visible at a glance
- Renders rich HTML content via the existing `HTMLViewer` component
- Loading skeleton + empty state (incl. on API failure)
- "All" affordance links to `/portal/scheduler-updates`

Data comes from the already-existing `schedulerUpdatesAPI.getAll()` (no backend changes).

## Files

- `components/dashboard/SchedulerUpdatesWidget.tsx` — new widget
- `app/portal/page.tsx` — wraps Upcoming Events + Scheduler Updates in a vertical stack
- `__tests__/unit/dashboard/SchedulerUpdatesWidget.test.tsx` — 6 component tests

## Test plan

- [x] Unit tests pass: 126/126 (6 new tests added, all green)
- [x] `tsc --noEmit` clean
- [ ] Manual verification: load `/portal` and confirm Scheduler Updates renders below Upcoming Events with the latest update auto-expanded
- [ ] Manual verification: click another update — accordion toggles correctly
- [ ] Manual verification: empty state when no updates exist

https://claude.ai/code/session_01VSEQ7vDfP6qUocCEGfaTNM

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSEQ7vDfP6qUocCEGfaTNM)_